### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by Claude"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION



## 🤖 New release

* `communique`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12

### Other

- Build communique from main before checking out PR branch
- Fix previous_tag to fall back to root commit when no tags exist
- Support non-tag refs and integrate communique into release-plz workflow
- Add usage-lib for auto-generated CLI reference docs
- Add progress indication via clx
- Add README with roadmap
- Add VitePress docs site with vaporwave theme
- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).