### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- VitePress documentation site with vaporwave theme, including getting-started guide, configuration reference, and auto-generated CLI reference
+- README with installation instructions, quick start guide, and project roadmap
+- Progress indication via `clx` — spinners and status messages while fetching PRs and waiting on the LLM
+- `usage-lib` integration for auto-generated CLI reference docs
+- `hk` pre-commit hooks with `cargo-clippy` and `cargo-fmt` linters
+- Lint CI workflow (`cargo clippy` + `cargo fmt`)
+- Rust build cache (`Swatinem/rust-cache`) in release-plz workflow
 
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no tags exist, preventing failures on first release
+- `resolve_ref` gracefully falls back to HEAD when a ref doesn't exist yet (e.g. unreleased version tags)
+- Non-tag refs (branches, SHAs) now work correctly as version arguments
+
+### Changed
+- Agent output uses structured tool calls (`submit_release_notes`) instead of text parsing with `---SECTION_BREAK---` delimiters
+- TOML config parse errors now display rich diagnostics via `miette` with source spans
+- Release-plz workflow builds communique from `main` before checking out PR branch, and uses debug builds for faster CI
+- Communique is now integrated into the release-plz workflow to auto-editorialize release notes and changelog entries on both releases and release PRs
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by Claude"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Documentation, Polish, and Self-Hosting

Communiqué v0.1.1 rounds out the initial release with a full documentation site, UX improvements like progress spinners and rich error diagnostics, and a robust CI pipeline. Most notably, communique now dogfoods itself — it's integrated into its own release-plz workflow to auto-editorialize the very release notes you're reading.

## 📚 Documentation Site

A VitePress-powered documentation site is now available with a vaporwave-inspired theme. It includes a [Getting Started guide](docs/guide/getting-started.md), [Configuration reference](docs/guide/configuration.md), and auto-generated CLI reference pages via `usage-lib`. A README with installation instructions, quick start, and a project roadmap rounds out the onboarding story.

## ✨ UX Improvements

- **Progress indication** — The CLI now shows spinners and contextual status messages (via `clx`) while discovering the repo, fetching PRs, and waiting on the LLM. Non-interactive terminals automatically fall back to plain text output.
- **Rich TOML error diagnostics** — Invalid `communique.toml` files now produce `miette`-powered error messages with source spans pointing directly at the problem, instead of opaque parse errors.
- **Structured output** — The agent now delivers results via a `submit_release_notes` tool call with typed fields (`changelog`, `release_title`, `release_body`), replacing the previous fragile `---SECTION_BREAK---` text parsing. This makes output extraction reliable and eliminates a class of parse failures.

## 🔧 Git & Ref Handling Fixes

- **First-release support** — `previous_tag` now falls back to the repository root commit when no prior tags exist, so the very first release captures the full history instead of erroring out.
- **`resolve_ref` fallback** — When a ref doesn't exist yet (e.g. a version tag that hasn't been created), the resolver gracefully falls back to HEAD rather than failing.
- **Non-tag refs** — Branches, commit SHAs, and other non-tag refs now work correctly as version arguments to `communique generate`.

## 🏗️ CI & Developer Experience

- **Lint workflow** — A new CI job runs `cargo clippy` and `cargo fmt` on every push and PR via [mise](https://mise.jdx.dev). (@jdx)
- **`hk` pre-commit hooks** — Local development is guarded by `cargo-clippy` and `cargo-fmt` hooks via [hk](https://github.com/jdx/hk).
- **Rust build cache** — The release-plz workflow now uses `Swatinem/rust-cache` for faster CI builds.
- **Self-hosting** — Communique is now integrated into its own release-plz workflow. On release, it editorializes the GitHub Release body. On release PRs, it rewrites the CHANGELOG.md entry and PR description with AI-generated notes — the tool writing its own release notes. (@jdx)