### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Progress indication with spinners and status messages via `clx` during repo discovery, git log reading, and AI generation
+- VitePress documentation site with a custom vaporwave theme, guide pages, and auto-generated CLI reference
+- `usage-lib` integration for auto-generated CLI reference docs (`communique usage` subcommand)
+- README with installation instructions, quick start guide, and project roadmap
+- `hk` pre-commit hooks with `cargo-clippy` and `cargo-fmt` linting
+- Lint CI workflow using `mise run lint`
+- Rust cache in release-plz CI workflow for faster builds
+- `communique.toml` TOML parse errors now display rich diagnostics via `miette` with source spans
 
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the repository root commit when no tags exist, preventing errors on first release
+- `resolve_ref` falls back to HEAD when a ref doesn't exist (e.g. a tag not yet created), preventing failures during release-plz workflows
+- Non-tag refs (branches, commit SHAs) are now supported as version references
+
+### Changed
+- Agent output now uses a structured `submit_release_notes` tool call instead of text parsing with `---SECTION_BREAK---` delimiters, making output extraction more reliable
+- Release-plz workflow builds communique from main before checking out the PR branch, ensuring a working binary is available
+- Release-plz workflow now uses debug builds for speed and integrates communique to editorialize both PR bodies and GitHub releases
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by Claude"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# The Agent Awakens — Structured Output, Docs, and Polish

communiqué v0.1.1 brings the developer experience up to speed: a full documentation site, progress spinners during generation, structured tool-call output from the AI agent, and a set of bug fixes that make communiqué work reliably as part of automated release-plz workflows.

## 🔄 Structured Agent Output

The AI agent now delivers its final output by calling a `submit_release_notes` tool instead of relying on fragile text-delimiter parsing. This makes output extraction deterministic — the agent returns structured JSON with `changelog`, `release_title`, and `release_body` fields, eliminating parsing failures.

## ⏳ Progress Indication

Long-running operations now show spinners and status messages via [`clx`](https://github.com/jdx/clx). Users see real-time feedback as communiqué discovers the repo, reads the git log, runs tools, and generates notes. Non-interactive environments automatically fall back to plain text output.

## 📖 Documentation Site

A VitePress-powered docs site has been added at `docs/`, complete with:
- A custom **vaporwave** theme (neon gradients, Orbitron headings, animated grid background)
- Getting started guide and configuration reference
- Auto-generated CLI reference via `usage-lib` and the hidden `communique usage` subcommand

## 🐛 First-Release & Non-Tag Ref Fixes

Several fixes make communiqué work correctly in edge cases encountered during automated release workflows:

- **`previous_tag` root commit fallback** — When no previous tags exist (e.g. on a project's very first release), communiqué now falls back to the repository's root commit instead of erroring out.
- **`resolve_ref` HEAD fallback** — When a tag hasn't been created yet (common in release-plz PR workflows), ref resolution gracefully falls back to HEAD.
- **Non-tag ref support** — Branches and commit SHAs now work as version references, not just tags.

## 🔧 CI & DX Improvements

- **`hk` pre-commit hooks** — `cargo-clippy` and `cargo-fmt` run automatically on commit via [hk](https://github.com/jdx/hk) (@jdx)
- **Lint CI workflow** — A new GitHub Actions workflow runs `mise run lint` on pushes and PRs
- **Rust cache** — The release-plz workflow now caches Rust builds via `Swatinem/rust-cache`
- **Self-hosting in CI** — The release-plz workflow builds communiqué from `main` and uses it to editorialize both release PR bodies and GitHub release notes
- **Rich TOML errors** — Invalid `communique.toml` files now produce `miette` diagnostic errors with source spans pointing to the exact problem

## Contributors

- @jdx