### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Progress indication with spinner and status messages during generation
+- Link verification for generated release notes (checks for broken URLs)
+- Emoji toggle via `emoji` config option in `communique.toml`
+- `verify_links` config option to control automatic link checking
+- Support for non-tag refs (commit SHAs, branches) as the previous release reference
+- Fallback to root commit when no previous tags exist, capturing full history
+- Structured `submit_release_notes` tool call for more reliable AI output
+- Improved TOML config error reporting with highlighted source spans via miette
+- `usage` subcommand for auto-generated CLI reference
+- Documentation website (VitePress)
 
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- Previous tag detection now gracefully handles repos with no tags
+- Ref resolution falls back to HEAD when a tag hasn't been created yet
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by Claude"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Progress, Polish, and a Docs Site

This release adds real-time progress feedback, automatic link verification, new configuration options, and a documentation website. It also improves reliability when working with repos that have no prior tags or when referencing non-tag commits.

## Progress Indication

communiqué now shows a spinner with contextual status messages as it works — discovering the repo, fetching git logs, calling tools, and generating notes. In non-interactive environments (e.g. CI), output falls back to plain text.

## Link Verification

Generated release notes are now automatically scanned for broken URLs. Any links returning 404 are flagged as warnings. This is enabled by default and can be controlled via `communique.toml`:

```toml
[defaults]
verify_links = false
```

## New Configuration Options

Two new options in `communique.toml`:

- **`emoji`** — Set to `false` to suppress emoji in all generated output (headings, titles, prose).
- **`verify_links`** — Set to `false` to skip automatic link checking.

```toml
[defaults]
emoji = true
verify_links = true
```

## New Subcommands

- **`communique init`** — Generates a starter `communique.toml` in your repo root. Use `--force` to overwrite an existing config.
- **`communique usage`** — Prints auto-generated CLI reference documentation.

## Improved Git Handling

- Non-tag refs (commit SHAs, branch names) are now supported as the previous release reference, making communiqué usable in more workflows.
- When no previous tags exist, communiqué falls back to the root commit so the full project history is captured.
- Ref resolution gracefully falls back to HEAD when a tag hasn't been pushed yet.

## Structured Output

The AI agent now uses a dedicated `submit_release_notes` tool call to deliver its final output, replacing free-form text parsing. This makes output extraction more reliable and eliminates parsing failures.

## Documentation Site

A VitePress-powered documentation site is now available, covering installation, getting started, CLI reference, and configuration.

## Better Error Reporting

TOML configuration errors now display highlighted source spans via miette, pointing directly to the problematic line in `communique.toml`.

---

All changes by @jdx.