### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing to GitHub or verifying links
+- Automatic link verification that checks all URLs in generated notes and asks the agent to fix broken links
+- Emoji toggle via `defaults.emoji` config option to control emoji usage in output
+- `verify_links` config option to enable/disable link verification (defaults to `true`)
+- Progress indication with spinners and status messages during generation
+- Structured `submit_release_notes` tool call for more reliable output from the AI agent
+- Release body template with narrative summary, highlights, and changelog sections
+- VitePress documentation site with getting-started guide and configuration reference
+- Auto-generated CLI reference docs via usage-lib
 
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the repository root commit when no prior tags exist
+- Non-tag refs (branches, commit SHAs) are now supported — `resolve_ref` falls back to HEAD if a ref doesn't exist yet
+- TOML configuration errors now display precise source spans via miette for easier debugging
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by Claude"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Dry-run mode, link verification, and progress spinners

communiqué v0.1.1 is the first feature release, adding dry-run mode for previewing release notes without side effects, automatic link verification that catches broken URLs before they ship, and progress spinners so you know what the agent is doing while it thinks.

## Highlights

- **Dry-run mode** — Use `--dry-run` / `-n` to preview generated release notes without updating GitHub releases or verifying links
- **Automatic link verification** — All URLs in generated notes are checked; broken links are sent back to the agent for correction
- **Progress indication** — Spinners and status messages show what communiqué is doing at each step (fetching git log, calling tools, verifying links)
- **Documentation site** — A VitePress-powered docs site with getting-started guide, configuration reference, and auto-generated CLI docs

## What's Changed

### Added

- **Dry-run mode** (`--dry-run` / `-n`) previews release notes without publishing to GitHub or verifying links (@jdx)
  ```sh
  communique generate v1.0.0 --dry-run
  ```
- **Link verification** automatically checks all URLs in generated notes and asks the agent to fix any broken links. Controlled via the `verify_links` config option (defaults to `true`). Disabled automatically in dry-run mode. (@jdx)
  ```toml
  [defaults]
  verify_links = true
  ```
- **Emoji toggle** via `defaults.emoji` config option — set to `false` to instruct the agent to omit emoji from all output (@jdx)
  ```toml
  [defaults]
  emoji = false
  ```
- **Progress spinners** with contextual status messages during each phase of generation (@jdx)
- **Structured `submit_release_notes` tool call** replaces text-based output parsing — the agent now submits changelog, release title, and release body via a dedicated tool, making output more reliable (@jdx)
- **Release body template** baked into the system prompt guides the agent to produce consistent, well-structured release notes with narrative summaries, highlights, and grouped changes (@jdx)
- **`communique init` subcommand** generates a commented `communique.toml` config file in the repo root (@jdx)
- **VitePress documentation site** with a getting-started guide, configuration reference, and auto-generated CLI reference docs via usage-lib (@jdx)

### Fixed

- **`previous_tag` falls back to root commit** when no prior tags exist, so the first release in a repository captures the full history (@jdx)
- **Non-tag refs now supported** — `resolve_ref` falls back to HEAD when a ref (e.g. an unpushed tag or branch name) doesn't exist yet, preventing errors in release-plz workflows (@jdx)
- **TOML config errors show precise source locations** via miette, making configuration mistakes much easier to diagnose (@jdx)