### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use any OpenAI API-compatible model by setting `--provider openai` or auto-detect from model name
+- Dry-run mode (`--dry-run` / `-n`) to preview generated release notes without publishing to GitHub or verifying links
+- Automatic link verification — all URLs in generated release notes are checked for broken links before submission
+- Emoji toggle — disable emoji in output via `communique.toml` (`emoji = false`)
+- Style matching — automatically fetches recent releases to match existing tone and formatting
+- Progress indication via spinners showing current agent status
+- `communique init` subcommand to scaffold a `communique.toml` config file
+- Structured tool call (`submit_release_notes`) for reliable output parsing
+- Release body template included in the system prompt for consistent formatting
+- Configurable `base_url` for self-hosted or proxy LLM endpoints
 
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist
+- Git ref resolution falls back to HEAD when a tag hasn't been created yet
+
+### Changed
+- Provider is auto-detected from model name (`claude*` → Anthropic, everything else → OpenAI)
+- API key resolution is provider-aware (`ANTHROPIC_API_KEY` for Anthropic, `OPENAI_API_KEY` or `LLM_API_KEY` for OpenAI)
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Multi-Provider LLM, Dry-Run Mode, and Link Verification

communiqué v0.1.1 is a significant feature release that opens up multi-provider LLM support, adds dry-run mode for safe previewing, and introduces automatic link verification to catch broken URLs before release notes go live. This release also brings a new `communique init` subcommand and a full `communique.toml` configuration system for customizing behavior.

## Highlights

- **Multi-provider LLM support** — Use any OpenAI API-compatible model alongside Anthropic Claude. Provider is auto-detected from the model name, or set explicitly with `--provider`.
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links using `--dry-run` / `-n`.
- **Automatic link verification** — All URLs in generated release notes are checked for broken links; the agent is asked to fix any issues before final output.
- **`communique init`** — Scaffold a `communique.toml` config file to customize model, provider, emoji, link verification, and style matching defaults.

## What's Changed

### Added
- **Multi-model LLM support with OpenAI-compatible provider.** Set `--provider openai` or let communiqué auto-detect from the model name (`claude*` → Anthropic, everything else → OpenAI). Configurable `--base-url` lets you point at self-hosted or proxy endpoints. (@jdx)
  ```sh
  communique generate v1.0.0 --model gpt-4o --provider openai
  # or auto-detected:
  communique generate v1.0.0 --model gpt-4o
  ```
- **Dry-run mode** (`--dry-run` / `-n`) — generate and preview release notes without updating GitHub or verifying links. (@jdx)
- **Automatic link verification** — after the LLM generates notes, all URLs are checked via HEAD/GET requests. Broken links are sent back to the model for correction before final output. (@jdx)
- **Emoji toggle** — disable emoji in all output by setting `emoji = false` in `communique.toml`. (@jdx)
- **Style matching** — communiqué fetches up to 2 recent GitHub releases and includes them in the prompt so the LLM matches your existing tone and formatting. Controlled via `match_style` in config. (@jdx)
- **`communique init` subcommand** — generates a `communique.toml` config file with commented-out defaults. Use `--force` to overwrite. (@jdx)
- **Progress indication** via `clx` spinners showing current agent status (discovering repo, fetching context, thinking, running tools, verifying links). (@jdx)
- **Structured `submit_release_notes` tool call** — the LLM now outputs release notes via a structured tool call with `changelog`, `release_title`, and `release_body` fields, replacing fragile text-based parsing. (@jdx)
- **`communique.toml` configuration** — full config file support with `system_extra`, `context`, and `[defaults]` section for model, max_tokens, repo, provider, base_url, emoji, verify_links, and match_style. (@jdx)

### Fixed
- **`previous_tag` fallback** — when no prior tags exist, communiqué now falls back to the root commit so the full history is captured. (@jdx)
- **Git ref resolution fallback** — `resolve_ref` falls back to HEAD when a tag hasn't been created yet, preventing errors during release-plz workflows. (@jdx)

### Changed
- **Provider auto-detection** — provider is inferred from the model name (`claude*` → Anthropic, everything else → OpenAI) when `--provider` is not specified. (@jdx)
- **Provider-aware API key resolution** — uses `ANTHROPIC_API_KEY` for Anthropic and `OPENAI_API_KEY` or `LLM_API_KEY` for OpenAI-compatible providers. (@jdx)