### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support: use OpenAI-compatible providers in addition to Anthropic/Claude, with auto-detection from model name
+- New `--provider` and `--base-url` CLI flags for specifying LLM provider and endpoint
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Automatic link verification that detects broken URLs in generated notes and asks the model to fix them
+- Progress indication with spinner and status messages during generation
+- Emoji toggle via `emoji` config option in `communique.toml`
+- Style matching: fetches recent GitHub releases to match tone and formatting
+- Structured tool-call output (`submit_release_notes`) for more reliable results
+- VitePress documentation site and auto-generated CLI reference
+- New `communique.toml` config options: `provider`, `base_url`, `emoji`, `verify_links`, `match_style`
 
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no previous tags exist
+- `resolve_ref` falls back to HEAD when a ref doesn't exist (e.g., a tag not yet created)
+- Support for non-tag refs (branches, commit SHAs) in version ranges
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

communiqué v0.1.1 is a major feature expansion that opens up LLM provider choice, adds safety features for generated content, and improves the overall generation experience with progress feedback and style matching.

## Highlights

- **Multi-provider LLM support** — Use any OpenAI-compatible API (OpenAI, Ollama, vLLM, etc.) alongside Anthropic/Claude. The provider is auto-detected from the model name, or set explicitly with `--provider`.
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links using `--dry-run` / `-n`.
- **Automatic link verification** — After generation, all URLs in the release notes are checked for 404s. Broken links are sent back to the model for correction.
- **Style matching** — Recent releases from your repo are fetched and included in the prompt so the AI matches your project's existing tone and formatting.

## What's Changed

### Added

- **Multi-model LLM support** with a new `LlmClient` trait and OpenAI-compatible provider implementation. Auto-detects `anthropic` for `claude*` models, falls back to `openai` for everything else. Use `OPENAI_API_KEY` or `LLM_API_KEY` for non-Anthropic providers.
  ```sh
  communique generate v1.0.0 --provider openai --model gpt-4o
  communique generate v1.0.0 --base-url <your-endpoint> --model llama3
  ```
- **`--dry-run` / `-n` flag** — generates release notes and prints them without updating GitHub releases or verifying links.
- **Link verification** — extracts all URLs from generated notes and HEAD-requests each one, falling back to GET for servers that reject HEAD. Broken links trigger a follow-up agent loop asking the model to fix them. Controlled by the `verify_links` config option.
- **Progress indication** via `clx` — spinner with contextual status messages ("Discovering repository…", "Generating release notes…", "Verifying links…") throughout the generation process.
- **Style matching** — fetches up to 2 recent GitHub releases and includes them in the prompt as style references. Toggle with `match_style` in config.
- **Emoji toggle** — set `emoji = false` in `communique.toml` to suppress emoji in all generated output.
- **Structured tool-call output** — the model now calls a `submit_release_notes` tool with `changelog`, `release_title`, and `release_body` fields instead of using text delimiters, making output parsing much more reliable.
- **New `communique.toml` config options**: `provider`, `base_url`, `emoji`, `verify_links`, `match_style` under `[defaults]`.
- **VitePress documentation site** with auto-generated CLI reference via `usage-lib`.

### Fixed

- **`previous_tag` fallback** — when no previous tags exist (e.g., first release), the tool now falls back to the root commit instead of erroring.
- **`resolve_ref` fallback** — when a ref doesn't exist yet (e.g., a version tag being created by the release process), it falls back to HEAD.
- **Non-tag ref support** — branches and commit SHAs now work as version range endpoints, not just tags.