### PR TITLE
Parallelize tool dispatch in agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "clx",
  "console",
  "env_logger",
+ "futures-util",
  "log",
  "miette",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ console = "0.16"
 env_logger = "0.11"
 toml = "0.8"
 xx = "2"
+futures-util = { version = "0.3.31", default-features = false }
 
 [dev-dependencies]
 wiremock = "0.6"


### PR DESCRIPTION
## Summary
- Tool calls from a single LLM turn are now executed concurrently using `futures_util::future::join_all` instead of sequentially in a `for` loop
- This speeds up iterations where the model issues multiple GitHub API calls (e.g. `get_pr` + `get_pr_diff` for several PRs at once)
- Uses the lightweight `futures-util` crate (no default features) to avoid pulling in the full `futures` ecosystem

## Test plan
- [x] All 10 existing tests pass (`cargo test`)
- [x] `cargo clippy` and `cargo fmt` pass (verified by pre-commit hooks)
- [ ] Manual test with a real release to confirm concurrent PR fetching works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)