### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use any OpenAI API-compatible model (GPT-4, Llama, etc.) alongside Anthropic Claude, with auto-detection from model name
+- Dry-run mode (`--dry-run` / `-n`) to preview generated release notes without publishing to GitHub or verifying links
+- Link verification in the agent loop — broken URLs in generated notes are automatically detected and the model is asked to fix them
+- Progress indication with spinner and status messages during generation via `clx`
+- Subcommands: `communique generate`, `communique init`, and `communique usage`
+- `communique.toml` configuration file with support for default model, provider, base URL, emoji toggle, link verification, style matching, and custom system prompt additions
+- `--provider`, `--base-url`, and `--model` CLI flags for per-invocation LLM configuration
+- Structured tool call (`submit_release_notes`) for more reliable output parsing
+- VitePress documentation site with CLI reference
+- Auto-generated CLI reference docs via `usage-lib`
 
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the repository root commit when no prior tags exist, preventing errors on first releases
+- Git ref resolution falls back to HEAD when a tag doesn't exist yet (e.g., during release-plz workflows)
+- TOML config parse errors now show source spans via `miette` for better diagnostics
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Multi-Model LLM Support, Dry-Run Mode, and Link Verification

communiqué v0.1.1 is a major feature expansion that transforms the tool from a single-provider prototype into a flexible, configurable release notes generator. This release adds multi-model LLM support, a configuration file, dry-run mode, automatic link verification, and a proper subcommand-based CLI.

## Highlights

- **Multi-model LLM support** — Use any OpenAI API-compatible model alongside Anthropic Claude. The provider is auto-detected from the model name (`claude*` → Anthropic, everything else → OpenAI), or can be set explicitly.
- **`communique.toml` configuration** — Run `communique init` to generate a config file with defaults for model, provider, emoji, link verification, style matching, and custom system prompt additions.
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links using `--dry-run` / `-n`.
- **Automatic link verification** — URLs in generated notes are checked for broken links; if any are found, the model is asked to fix them before final output.

## What's Changed

### Added

- **Multi-provider LLM architecture**: A new `LlmClient` trait abstracts away provider details, with implementations for both Anthropic and OpenAI-compatible APIs. Provider auto-detection routes `claude*` models to Anthropic and everything else to the OpenAI endpoint. Configure via `--provider`, `--base-url`, and `--model` flags, or set defaults in `communique.toml`. (@jdx)
- **Subcommand CLI structure**: The CLI now uses subcommands — `communique generate` for release note generation, `communique init` to scaffold a `communique.toml` config file, and `communique usage` for auto-generated CLI reference. (@jdx)
- **`communique.toml` configuration file**: Supports `system_extra` (custom system prompt additions), `context` (project description included in every prompt), and a `[defaults]` section for `model`, `max_tokens`, `repo`, `provider`, `base_url`, `emoji`, `verify_links`, and `match_style`. (@jdx)
  ```toml
  system_extra = "Always be concise"
  context = "A CLI tool for AI-generated release notes"

  [defaults]
  model = "claude-opus-4-6"
  emoji = true
  verify_links = true
  match_style = true
  ```
- **Dry-run mode** (`--dry-run` / `-n`): Previews generated release notes without updating the GitHub release or verifying links. (@jdx)
- **Link verification**: After the model submits release notes, all URLs are checked for 404s. Broken links are reported back to the model with a request to fix or remove them, and the model resubmits. (@jdx)
- **Structured tool call output**: The model now calls a `submit_release_notes` tool with `changelog`, `release_title`, and `release_body` fields, replacing text-based output parsing for more reliable results. (@jdx)
- **Progress indication**: A spinner with status messages shows what's happening at each stage — discovering the repo, fetching git logs, generating notes, verifying links, and publishing. (@jdx)
- **Style matching**: Recent release notes from the same repository are fetched and included in the prompt so the model can match existing tone and formatting conventions. (@jdx)
- **VitePress documentation site** with auto-generated CLI reference via `usage-lib`. (@jdx)

### Fixed

- **`previous_tag` falls back to root commit**: When no prior tags exist (e.g., a project's first release), the tool now falls back to the repository's initial commit instead of erroring out. (@jdx)
- **Git ref resolution falls back to HEAD**: When a tag doesn't exist yet (e.g., during `release-plz` workflows where the tag is created after the release notes), ref resolution gracefully falls back to HEAD. (@jdx)
- **Better TOML error diagnostics**: Config file parse errors now display source spans via `miette`, making it easy to locate syntax issues. (@jdx)

## Breaking Changes

- The CLI now uses subcommands. Instead of `communique v1.0.0`, use `communique generate v1.0.0`.