### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,27 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use any OpenAI API-compatible model via `--provider openai` and `--base-url`, with automatic provider detection from model name
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing to GitHub or verifying links
+- Automatic link verification that checks all URLs in generated notes for broken links and asks the LLM to fix them
+- Progress indication with spinners and status messages during generation
+- Emoji toggle (`emoji = false` in config) to suppress emoji in output
+- Style matching — fetches recent GitHub releases to match your project's existing tone and formatting
+- Structured output via `submit_release_notes` tool call for more reliable release note generation
+- VitePress documentation site with getting started guide and configuration reference
+- Auto-generated CLI reference docs via usage-lib
 
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist, enabling first-release support
+- Non-tag refs (branches, SHAs, unreleased versions) now resolve correctly via HEAD fallback
+- TOML config parse errors now display rich diagnostics with source spans via miette
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
# Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

communiqué v0.1.1 is the first feature release, significantly expanding the tool's capabilities since the initial v0.1.0. This release adds support for any OpenAI-compatible LLM provider, a dry-run mode for previewing notes before publishing, automatic broken link detection, and a documentation site.

## Highlights
- **Multi-provider LLM support** — use OpenAI, local models, or any OpenAI API-compatible provider alongside Anthropic Claude
- **Dry-run mode** — preview generated release notes without touching GitHub or verifying links
- **Automatic link verification** — all URLs in generated notes are checked, and broken links are sent back to the LLM for correction
- **Style matching** — fetches your recent GitHub releases so the AI can match your project's existing tone and formatting

## What's Changed

### Added
- **Multi-model LLM support** — Use any OpenAI API-compatible model with `--provider openai` and `--base-url`. The provider is auto-detected from the model name (`claude*` → Anthropic, everything else → OpenAI). (@jdx)
  ```sh
  communique generate v1.0.0 --model gpt-4 --provider openai
  ```
- **Dry-run mode** (`--dry-run` / `-n`) — Preview release notes locally without publishing to GitHub or verifying links. (@jdx)
- **Automatic link verification** — After the AI generates notes, all URLs are checked for broken links (404s, timeouts). If any are found, the LLM is asked to fix them before finalizing. Controlled via `verify_links` in config. (@jdx)
- **Progress indication** — Spinners and status messages (via `clx`) show what communiqué is doing at each step: discovering the repo, fetching context, generating notes, and verifying links. (@jdx)
- **Style matching** — Fetches up to 2 recent GitHub releases and includes them in the prompt so the AI can match your project's existing writing style. Toggle with `match_style` in config. (@jdx)
- **Emoji toggle** — Set `emoji = false` in `communique.toml` to suppress all emoji in generated output. (@jdx)
- **Structured tool-call output** — The AI now submits release notes via a `submit_release_notes` tool call with explicit `changelog`, `release_title`, and `release_body` fields, replacing fragile text parsing. (@jdx)
- **`communique init` subcommand** — Generates a starter `communique.toml` with commented-out defaults for all configuration options. (@jdx)
- **Documentation site** — A VitePress-powered docs site with a getting started guide, configuration reference, and auto-generated CLI docs via usage-lib. (@jdx)

### Fixed
- **First-release support** — `previous_tag` now falls back to the repository root commit when no prior tags exist, so you can generate notes for your very first release. (@jdx)
- **Non-tag ref resolution** — Branches, SHAs, and not-yet-created version tags now resolve correctly via a HEAD fallback instead of erroring. (@jdx)
- **Config error diagnostics** — TOML parse errors in `communique.toml` now display rich error messages with source spans and underlined locations via miette. (@jdx)