### PR TITLE
Add code coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,17 @@ jobs:
       - uses: jdx/mise-action@v2
       - run: mise run lint
       - run: cargo test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - run: cargo llvm-cov --codecov --output-path codecov.json
+      - uses: codecov/codecov-action@v5
+        with:
+          files: codecov.json


### PR DESCRIPTION
## Summary
- Add a parallel `coverage` job to the CI workflow using `cargo-llvm-cov`
- Upload results to Codecov via `codecov/codecov-action@v5`
- Runs alongside existing lint + test job without slowing it down

## Test plan
- [ ] Verify the coverage job runs successfully in this PR's CI
- [ ] Check Codecov receives the upload (may need the Codecov GitHub app installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)