### PR TITLE
Update release PR title with communique output

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -97,9 +97,11 @@ jobs:
           " <<< "$CONCISE_NOTES"
           fi
 
-          # Update PR body with full release notes
+          # Update PR title and body with full release notes
           FULL_NOTES=$($COMMUNIQUE generate "$TAG")
-          gh pr edit "$PR_NUMBER" --body "$FULL_NOTES"
+          PR_TITLE=$(echo "$FULL_NOTES" | head -1 | sed 's/^# //')
+          PR_BODY=$(echo "$FULL_NOTES" | tail -n +3)
+          gh pr edit "$PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
 
           # Commit and push changelog changes
           if ! git diff --quiet CHANGELOG.md 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Parse the release title from communique's `# Title` output line and use it as the PR title via `gh pr edit --title`
- Strip the `# ` heading prefix from the title and the heading line from the body so they're cleanly separated

Previously only the PR body was updated; the title stayed as the default release-plz title.

## Test plan
- [ ] Merge and verify the next release-plz PR gets a communique-generated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)