### PR TITLE
Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider (auto-detects from model name; `claude*` → Anthropic, everything else → OpenAI)
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Link verification: automatically checks all URLs in generated notes for broken links and asks the LLM to fix them
+- Emoji toggle: disable emoji in output via `communique.toml` (`emoji = false`)
+- Style matching: fetches recent GitHub releases to match your project's existing tone and formatting
+- Progress indication with spinners via `clx` for all long-running operations
+- `communique init` subcommand to generate a starter `communique.toml` config file
+- `communique.toml` configuration file with support for `system_extra`, `context`, defaults for model/provider/base_url, and more
+- Structured output via `submit_release_notes` tool call for more reliable parsing
+- VitePress documentation site
+- Auto-generated CLI reference docs via `usage-lib`
 
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist, so first releases work correctly
+- Git ref resolution falls back to HEAD when a tag doesn't exist yet (e.g., during pre-release workflows)
+
+### Changed
+- LLM interaction refactored from Anthropic-only to a provider-agnostic `LlmClient` trait, enabling any OpenAI-compatible API
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is a major feature expansion over the initial release. The LLM backend is now provider-agnostic — bring your own OpenAI-compatible endpoint or stick with Anthropic Claude. A new dry-run mode lets you preview release notes without side effects, and automatic link verification catches broken URLs before they reach your users.

## Highlights
- **Multi-provider LLM support** — Use any OpenAI-compatible API alongside Anthropic Claude. Provider is auto-detected from the model name (`claude*` → Anthropic, everything else → OpenAI), or set explicitly via `--provider` or `communique.toml`.
- **Dry-run mode** — Pass `--dry-run` / `-n` to generate release notes without publishing to GitHub or verifying links.
- **Link verification** — All URLs in generated notes are automatically checked; broken links are fed back to the LLM for correction.
- **`communique.toml` configuration** — Centralize defaults for model, provider, emoji, link verification, style matching, and more. Run `communique init` to get started.

## What's Changed

### Added
- **Multi-model LLM support** with OpenAI-compatible provider. Auto-detects provider from model name, or configure explicitly via `--provider` flag or `communique.toml`. (@jdx)
  ```toml
  # communique.toml
  [defaults]
  model = "gpt-4"
  provider = "openai"
  ```
- **Dry-run mode** (`--dry-run` / `-n`) — preview release notes without updating GitHub releases or verifying links. (@jdx)
- **Automatic link verification** — after generating notes, all URLs are checked for 404s. Broken links are sent back to the LLM to fix before final output. (@jdx)
- **Emoji toggle** — disable emoji in generated output by setting `emoji = false` in `communique.toml`. (@jdx)
- **Style matching** — fetches up to 2 recent GitHub releases and includes them in the prompt so the LLM matches your project's existing tone and formatting. Disable with `match_style = false`. (@jdx)
- **Progress indication** — spinners and status messages via `clx` for all long-running operations (git log, LLM calls, link verification). (@jdx)
- **`communique init` subcommand** — generates a starter `communique.toml` in your repo root. (@jdx)
- **`communique.toml` configuration file** — supports `system_extra` (append to the system prompt), `context` (project description included in every prompt), and a `[defaults]` section for model, max_tokens, repo, provider, base_url, emoji, verify_links, and match_style. (@jdx)
- **Structured tool-call output** — the LLM now calls `submit_release_notes` with structured JSON fields (`changelog`, `release_title`, `release_body`) instead of relying on text parsing, making output extraction more reliable. (@jdx)
- **VitePress documentation site** with auto-generated CLI reference docs via `usage-lib`. (@jdx)

### Fixed
- **First-release support** — `previous_tag` now falls back to the root commit when no prior tags exist, so `communique generate v0.1.0` works on brand-new repos. (@jdx)
- **Pre-release workflow support** — git ref resolution falls back to HEAD when a tag doesn't exist yet (e.g. generating notes before the tag is pushed). (@jdx)

### Changed
- The LLM interaction layer has been refactored from Anthropic-only to a provider-agnostic `LlmClient` trait, with concrete implementations for Anthropic and OpenAI. This enables using any OpenAI-compatible API (e.g. local models via Ollama, Azure OpenAI, etc.). (@jdx)