### PR TITLE
The Full-Featured Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,31 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible providers — auto-detects provider from model name, or configure explicitly with `--provider` / `defaults.provider`
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing to GitHub or verifying links
+- Link verification — automatically checks all URLs in generated release notes and asks the AI to fix broken links
+- Progress indication with spinners showing current agent iteration and tool calls
+- `communique.toml` configuration file with `communique init` command to scaffold it
+- Style matching — fetches recent GitHub releases and asks the AI to match their tone and formatting
+- Emoji toggle — disable emoji in output via `defaults.emoji = false` in config
+- Auto-generated CLI reference docs via usage-lib
+- VitePress documentation site
+- Support for non-tag refs (commit SHAs, branches) in tag arguments
 
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to root commit when no prior tags exist, enabling first-release generation
+- Ref resolution falls back to HEAD when a tag doesn't exist yet (e.g. during pre-release workflows)
+
+### Changed
+- Output is now captured via structured `submit_release_notes` tool call instead of text parsing, improving reliability
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 transforms the initial CLI skeleton into a full-featured AI release notes generator. This release adds multi-model LLM support, a configuration file, dry-run mode, automatic link verification, progress spinners, style matching, and a documentation site — essentially everything needed to use communiqué in production workflows.

## Highlights

- **Multi-model LLM support** — Use any OpenAI-compatible provider alongside Anthropic. Provider is auto-detected from the model name, or set explicitly via `--provider` or `communique.toml`.
- **`communique.toml` config file** — Persist defaults for model, provider, emoji, link verification, and custom system prompt instructions. Scaffold one with `communique init`.
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links (`--dry-run` / `-n`).
- **Automatic link verification** — All URLs in generated notes are checked, and broken links are sent back to the AI for correction.

## What's Changed

### Added

- **Multi-model LLM support** with OpenAI-compatible providers. Auto-detects `anthropic` for `claude*` models, defaults to `openai` for everything else. Configure with `--provider`, `--base-url`, or in `communique.toml`. (@jdx)
- **Dry-run mode** (`--dry-run` / `-n`) to generate and preview release notes without updating GitHub releases or verifying links. (@jdx)
- **Link verification** in the agent loop — after the AI submits release notes, all URLs are checked via HEAD requests (with GET fallback for 405s). Broken links are reported back to the model to fix before finalizing. (@jdx)
- **Progress indication** via `clx` spinners showing the current agent iteration and active tool calls. (@jdx)
- **`communique.toml` configuration** with `communique init` to scaffold it. Supports `system_extra`, `context`, and a `[defaults]` section for `model`, `max_tokens`, `repo`, `provider`, `base_url`, `emoji`, `verify_links`, and `match_style`. (@jdx)

  ```toml
  system_extra = "Keep notes concise and technical"
  context = "A CLI tool for AI-powered release notes"

  [defaults]
  model = "claude-opus-4-6"
  emoji = true
  verify_links = true
  match_style = true
  ```

- **Style matching** — fetches up to 2 recent GitHub releases and includes them in the prompt so the AI matches the project's existing tone and formatting. Disable with `defaults.match_style = false`. (@jdx)
- **Emoji toggle** — set `defaults.emoji = false` in config to suppress emoji in all output. (@jdx)
- **Structured output** via a `submit_release_notes` tool call, replacing fragile text parsing with a reliable JSON schema for `changelog`, `release_title`, and `release_body`. (@jdx)
- **Support for non-tag refs** — pass commit SHAs or branch names as tag arguments. Refs that don't exist yet (e.g. pre-release tags) gracefully fall back to HEAD. (@jdx)
- **Auto-generated CLI reference docs** via `usage-lib` and a VitePress documentation site. (@jdx)

### Fixed

- **`previous_tag` falls back to root commit** when no prior tags exist, enabling release notes generation for the very first release. (@jdx)
- **Ref resolution falls back to HEAD** when a tag doesn't exist yet, supporting pre-release workflows where the tag is created after notes are generated. (@jdx)
- **TOML parse errors** now display as rich `miette` diagnostics with source spans. (@jdx)