### PR TITLE
Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,32 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support: use OpenAI, or any OpenAI-compatible API, in addition to Anthropic Claude — auto-detected from model name or set via `--provider` / config
+- Dry-run mode (`--dry-run` / `-n`): preview generated release notes without publishing to GitHub or verifying links
+- Link verification: automatically checks all URLs in generated notes and asks the model to fix broken links
+- Progress indication with spinner and status messages while fetching PRs and waiting on the LLM
+- VitePress documentation site with getting started guide and configuration reference
+- Auto-generated CLI reference docs via usage-lib
+- Emoji toggle (`emoji` config option) to control emoji usage in output
+- Style matching (`match_style` config option) fetches recent releases to match your project's tone
+- New config options: `provider`, `base_url`, `emoji`, `verify_links`, `match_style`
+- Support for non-tag refs (branches, commit SHAs) as version arguments
 
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the repository root commit when no prior tags exist, fixing first-release generation
+- Git ref resolution falls back to HEAD when a tag doesn't exist yet (e.g. during pre-release workflows)
+
+### Changed
+- Release notes output now uses structured tool calls instead of text parsing, improving reliability
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is the first major feature release, transforming the tool from a Claude-only prototype into a flexible, multi-provider release notes generator. This release adds OpenAI-compatible model support, a dry-run preview mode, automatic link verification, progress indicators, and a full documentation site.

## Highlights

- **Multi-provider LLM support** — Use OpenAI, or any OpenAI-compatible API (local models, Azure, etc.), in addition to Anthropic Claude. Auto-detected from model name or set explicitly via `--provider` or config.
- **Dry-run mode** — Preview generated release notes with `--dry-run` / `-n` without publishing to GitHub or verifying links.
- **Link verification** — All URLs in generated notes are automatically checked; broken links are sent back to the model for correction before final output.
- **Documentation site** — A VitePress-powered docs site with getting started guide, configuration reference, and auto-generated CLI reference.

## What's Changed

### Added

- **Multi-model LLM support**: Use any OpenAI-compatible provider alongside Anthropic Claude. Auto-detected from model name (`claude*` → Anthropic, everything else → OpenAI), or set explicitly via `--provider` flag or `provider` config option. (@jdx)
  ```toml
  [defaults]
  model = "gpt-4"
  provider = "openai"
  ```
- **Dry-run mode** (`--dry-run` / `-n`): Generate and preview release notes locally without updating GitHub releases or running link verification. (@jdx)
- **Link verification**: After generating notes, all URLs are checked via HEAD requests (with GET fallback for 405 responses). Broken links are reported back to the LLM to fix before final submission. Controlled via `verify_links` config option. (@jdx)
- **Progress indication**: Spinner with status messages during PR fetching, LLM generation, and link verification using the `clx` library. (@jdx)
- **Style matching**: When `match_style` is enabled (default: `true`), communiqué fetches your most recent GitHub releases and includes them as a style reference for the LLM. (@jdx)
- **Emoji toggle**: Control emoji usage in generated output via the `emoji` config option. (@jdx)
- **Non-tag ref support**: Version arguments can now be branches, commit SHAs, or other git refs — not just tags. (@jdx)
- **`communique init` subcommand**: Generates a starter `communique.toml` config file in your repo root. (@jdx)
- **VitePress documentation site** with getting started guide, configuration reference, and auto-generated CLI docs via usage-lib. (@jdx)
- New config options in `[defaults]`: `provider`, `base_url`, `emoji`, `verify_links`, `match_style`

### Fixed

- **First-release generation**: `previous_tag` now falls back to the repository root commit when no prior tags exist, so generating notes for the very first release works correctly. (@jdx)
- **Pre-release tag resolution**: Git ref resolution falls back to HEAD when a tag doesn't exist yet, fixing workflows where notes are generated before the tag is created. (@jdx)

### Changed

- Release notes output now uses **structured tool calls** (`submit_release_notes`) instead of text parsing with section break markers, improving reliability and eliminating parsing failures. (@jdx)