### PR TITLE
Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add generate.rs integration tests and extract shared test helpers
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use any OpenAI API-compatible model alongside Anthropic Claude via `--provider` or config
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing to GitHub or verifying links
+- Automatic link verification — broken URLs in generated notes are detected and sent back to the model for correction
+- Progress indication with spinners showing current operation (fetching PRs, generating notes, verifying links)
+- Style matching — fetches recent GitHub releases to match tone and formatting conventions
+- Emoji toggle via `communique.toml` (`emoji = false` to suppress emoji in output)
+- VitePress documentation site with vaporwave theme
+- Auto-generated CLI reference docs via usage-lib
+- README with project roadmap
+- Structured `submit_release_notes` tool call for cleaner output parsing
 
-- Add generate.rs integration tests and extract shared test helpers
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist, enabling first-release generation
+- Non-tag refs (branches, commit SHAs) are now supported as version arguments
+- TOML config parse errors now display rich diagnostics with source spans via miette
+
+### Changed
+- Release notes output now uses a structured tool call (`submit_release_notes`) instead of text parsing with section break markers
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is the first feature release, adding multi-provider LLM support, a dry-run mode for previewing notes before publishing, and automatic link verification to catch broken URLs in generated release notes. The agent loop is now more robust with structured tool-call output parsing and progress spinners.

## Highlights

- **Multi-provider LLM support** — use OpenAI, or any OpenAI API-compatible model, alongside the default Anthropic Claude backend
- **Dry-run mode** — preview release notes locally without updating GitHub or verifying links
- **Automatic link verification** — broken URLs are detected and sent back to the model for self-correction
- **Style matching** — fetches your recent GitHub releases so the AI can match your project's existing tone

## What's Changed

### Added

- **Multi-model LLM support** with an `LlmClient` trait and OpenAI-compatible provider. Auto-detects provider from model name (`claude*` → Anthropic, everything else → OpenAI). Configure via `--provider`, `--model`, `--base-url` CLI flags or in `communique.toml`. (@jdx)
  ```toml
  [defaults]
  provider = "openai"
  model = "gpt-4"
  ```
- **Dry-run mode** (`--dry-run` / `-n`) skips GitHub release updates and link verification, letting you preview output locally. (@jdx)
- **Automatic link verification** — after the model generates notes, all URLs are checked for 404s. Broken links are reported back to the model with a request to fix them before final submission. (@jdx)
- **Progress spinners** via `clx` showing the current operation (discovering repo, reading git log, generating notes, verifying links). (@jdx)
- **Style matching** — automatically fetches up to 2 recent GitHub releases and includes them in the prompt so the AI can match your project's existing tone and formatting. Disable with `match_style = false` in config. (@jdx)
- **Emoji toggle** — set `emoji = false` in `communique.toml` `[defaults]` to suppress emoji in generated notes. (@jdx)
- **`communique init`** subcommand to generate a starter `communique.toml` config file. (@jdx)
- **Structured `submit_release_notes` tool call** — the model now returns output via a structured tool call with `changelog`, `release_title`, and `release_body` fields, replacing the previous text-based section-break parsing for more reliable results. (@jdx)

### Fixed

- **First-release support** — `previous_tag` now falls back to the repository root commit when no prior tags exist, so you can generate notes for your very first release. (@jdx)
- **Non-tag ref support** — branches, commit SHAs, and not-yet-created tags now work as version arguments by falling back to HEAD when the ref can't be resolved. (@jdx)
- **Better config error messages** — TOML parse errors now display rich diagnostics with source spans via miette, making it easy to find and fix config typos. (@jdx)