### PR TITLE
The Agent Awakens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,34 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use any OpenAI API-compatible model via `--provider openai` or auto-detect from model name
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Link verification in the agent loop — broken URLs are automatically detected and the model is asked to fix them
+- Configurable emoji toggle (`emoji` in `communique.toml` defaults) to suppress emoji in output
+- Progress indication via spinner/status while fetching PRs and waiting on the LLM
+- VitePress documentation site
+- `communique init` and `communique generate` subcommands with `communique.toml` configuration file
+- Style matching from recent releases — the agent reads your last 2 releases for tone/format consistency
+- Structured tool call (`submit_release_notes`) for cleaner, more reliable output parsing
 
-- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
-- Add generate.rs integration tests and extract shared test helpers
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Changed
+- Tool calls from a single LLM turn are now executed concurrently, speeding up iterations with multiple GitHub API calls
+
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist, instead of erroring
+- Git ref resolution falls back to HEAD when a tag doesn't exist yet (e.g. during release-plz workflows)
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
+- Add generate.rs integration tests and extract shared test helpers
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué's first feature release transforms the initial prototype into a fully functional AI-powered release notes generator. This release adds multi-provider LLM support, a proper CLI with subcommands and configuration, link verification, dry-run mode, and significant quality-of-life improvements.

## Highlights

- **Multi-provider LLM support** — Use Claude (Anthropic) or any OpenAI API-compatible model. The provider is auto-detected from the model name or set explicitly with `--provider`.
- **`communique.toml` configuration** — Run `communique init` to scaffold a config file with defaults for model, provider, emoji, link verification, style matching, and more.
- **Automatic link verification** — After generating notes, all URLs are checked for broken links. If any are found, the model is asked to fix them before finalizing.
- **Dry-run mode** — Use `--dry-run` / `-n` to preview release notes without publishing to GitHub or verifying links.

## What's Changed

### Added

- **Multi-model LLM support** with an OpenAI-compatible provider. Auto-detects `claude*` → Anthropic, everything else → OpenAI. Configure via CLI flags or `communique.toml`:
  ```toml
  [defaults]
  provider = "openai"
  model = "gpt-4"
  ```
- **`communique init` and `communique generate` subcommands** replacing the previous flat CLI. `generate` accepts `--github-release`, `--concise`, `--dry-run`, `--model`, `--provider`, `--base-url`, and more.
- **Dry-run mode** (`--dry-run` / `-n`) to preview generated notes without updating GitHub releases or verifying links.
- **Link verification** in the agent loop — all URLs in the generated notes are checked via HEAD requests (with GET fallback for 405s), and the model is prompted to fix any broken links.
- **Configurable emoji toggle** — set `emoji = false` in `communique.toml` to suppress emoji in all output.
- **Style matching from recent releases** — the agent fetches your last 2 GitHub releases and uses them as a style reference for tone and formatting consistency.
- **Progress indication** via spinner/status messages while discovering the repo, fetching PRs, and waiting on the LLM.
- **Structured tool call** (`submit_release_notes`) for output — the model returns changelog, release title, and release body as structured fields instead of relying on text parsing with delimiters.
- **VitePress documentation site** with auto-generated CLI reference.

### Changed

- **Concurrent tool dispatch** — tool calls from a single LLM turn are now executed in parallel using `futures_util::future::join_all`, speeding up iterations where the model issues multiple GitHub API calls simultaneously (#19, @jdx).

### Fixed

- **`previous_tag` falls back to the root commit** when no prior tags exist, instead of erroring — enables generating notes for a project's very first release.
- **Git ref resolution falls back to HEAD** when a tag doesn't exist yet (e.g. during release-plz workflows where the tag is created after the release PR merges).