### PR TITLE
Multi-Provider LLM Support, Dry-Run Mode, and Link Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,35 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support: use OpenAI, or any OpenAI-compatible provider, in addition to Anthropic Claude (`--provider`, `--base-url` flags or `communique.toml` config)
+- Dry-run mode (`--dry-run` / `-n`) to preview generated notes without updating GitHub or verifying links
+- Automatic link verification checks all URLs in generated release notes for broken links before publishing
+- Retry with exponential backoff for API calls, including `Retry-After` header support for rate limiting
+- Parallel tool dispatch — multiple tool calls from a single LLM turn now execute concurrently
+- Progress indication with spinner/status while fetching PRs and waiting on the LLM
+- Emoji toggle — disable emoji in output via `emoji = false` in `communique.toml`
+- Style matching — fetches recent releases to match your project's existing tone and formatting
+- VitePress documentation site
 
-- Add retry with exponential backoff for API calls
-- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
-- Add generate.rs integration tests and extract shared test helpers
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no prior tags exist, fixing first-release generation
+- Non-tag refs (commit SHAs, branches) are now supported as the `prev_tag` argument
+- Invalid `communique.toml` files now produce rich diagnostic errors via miette with source spans
+
+### Changed
+- Release notes output now uses structured tool calls instead of text parsing, improving reliability
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add retry with exponential backoff for API calls
+- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
+- Add generate.rs integration tests and extract shared test helpers
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is a feature-packed follow-up to the initial release, adding multi-provider LLM support, a dry-run mode for previewing notes before publishing, and automatic link verification to catch broken URLs before they hit your release page. The agent loop is now faster thanks to parallel tool dispatch, and API calls are resilient with automatic retry and exponential backoff.

## Highlights

- **Multi-provider LLM support** — Use OpenAI, or any OpenAI-compatible provider (Ollama, Together, etc.), in addition to Anthropic Claude
- **Dry-run mode** — Preview generated release notes without modifying GitHub or verifying links
- **Link verification** — All URLs in generated notes are automatically checked for broken links before publishing
- **Parallel tool dispatch** — Multiple tool calls from a single LLM turn now execute concurrently for faster generation

## What's Changed

### Added
- **Multi-model LLM support**: Use `--provider openai` or `--base-url` to point at any OpenAI-compatible API. Provider auto-detection works by model name (`claude*` → Anthropic, everything else → OpenAI). Configurable in `communique.toml`:
  ```toml
  [defaults]
  provider = "openai"
  model = "gpt-4"
  ```
- **Dry-run mode** (`--dry-run` / `-n`): Generate and print release notes without updating the GitHub release or running link verification (@jdx)
- **Automatic link verification**: All URLs in the generated changelog and release body are checked via HEAD requests (with GET fallback for 405 responses). If broken links are found, the agent is asked to fix them and resubmit
- **Retry with exponential backoff**: API calls to both LLM providers and GitHub automatically retry on 429/5xx errors with jitter, respecting `Retry-After` headers
- **Parallel tool dispatch**: Tool calls within a single LLM turn now execute concurrently using `futures_util::future::join_all`, speeding up iterations where the model fetches multiple PRs at once (#19, @jdx)
- **Progress indication**: Spinner and status messages while discovering the repo, fetching PRs, running tools, and waiting on the LLM
- **Style matching**: Fetches up to 2 recent releases from your repo and includes them as style reference in the prompt, so generated notes match your project's existing tone. Controlled via `match_style` in config
- **Emoji toggle**: Disable emoji in output with `emoji = false` in `communique.toml`
- **`communique init` subcommand**: Generates a starter `communique.toml` with all options documented

### Fixed
- `previous_tag` now falls back to the repository root commit when no prior tags exist, fixing release note generation for first releases
- Non-tag refs (commit SHAs, branches) are now accepted as the `prev_tag` argument — `resolve_ref` falls back to HEAD if the ref doesn't exist
- Invalid `communique.toml` files now produce rich diagnostic errors with source spans via miette, instead of opaque parse failures

### Changed
- Release notes output now uses a structured `submit_release_notes` tool call instead of text section parsing, improving reliability and making the agent loop cleaner