### PR TITLE
Multi-Provider LLM Support, Dry-Run Mode, and Smarter Agent Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,36 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use OpenAI, Groq, Together, Ollama, and more via `--provider` and `--base-url` flags or config
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Automatic retry with exponential backoff for API calls (Anthropic, OpenAI, and GitHub), with Retry-After header support for 429s
+- Link verification in the agent loop — broken URLs are sent back to the LLM for correction before finalizing
+- Parallel tool dispatch in the agent loop for faster multi-tool iterations
+- New agent tools: `get_issue`, `git_show`, and `get_commits` for richer repository context
+- Emoji toggle (`emoji` config option) to suppress emoji in generated output
+- `verify_links` config option (default: true) to control URL verification
+- `match_style` config option to match tone/structure of recent releases
+- Progress spinner with detailed status updates during generation
+- Structured release body template with Highlights, What's Changed, Breaking Changes, and New Contributors sections
+- VitePress documentation site with auto-generated CLI reference
 
-- Add get_issue, git_show, and get_commits agent tools
-- Add retry with exponential backoff for API calls
-- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
-- Add generate.rs integration tests and extract shared test helpers
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- `previous_tag` now falls back to the root commit when no tags exist, enabling first-release generation
+- `resolve_ref` no longer prints stderr when a ref doesn't exist
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add get_issue, git_show, and get_commits agent tools
+- Add retry with exponential backoff for API calls
+- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
+- Add generate.rs integration tests and extract shared test helpers
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is a major feature expansion that transforms the tool from an Anthropic-only CLI into a flexible, multi-provider release notes generator with a significantly smarter agent loop. This release adds support for any OpenAI-compatible LLM provider, introduces dry-run mode for safe previews, and makes the agent self-correcting with automatic link verification and retry logic.

## Highlights

- **Multi-provider LLM support** — Use OpenAI, Groq, Together, Ollama, or any OpenAI-compatible API alongside Anthropic. Provider auto-detects from model name (`claude*` → Anthropic, everything else → OpenAI).
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links.
- **Self-correcting link verification** — Broken URLs in generated output are sent back to the LLM for correction before finalizing, rather than just warning after the fact.
- **Automatic retry with exponential backoff** — Transient API failures (429, 500, 502, 503) are retried automatically with jitter and `Retry-After` header support.

## What's Changed

### Added

- **Multi-model LLM support** with an `LlmClient` trait abstracting provider interactions. Anthropic and OpenAI-compatible providers are both supported, with auto-detection from model name. Configure via `--provider` and `--base-url` CLI flags or the `[defaults]` section in `communique.toml`. (@jdx)

- **Dry-run mode** (`--dry-run` / `-n`) skips GitHub publishing and link verification, useful for testing prompts and reviewing output. (@jdx)

- **Retry with exponential backoff** for all HTTP calls to Anthropic, OpenAI, and GitHub APIs. Handles 429 rate limits with `Retry-After` header support, and retries on 500/502/503/529 errors up to 5 times. (@jdx)

- **Link verification in the agent loop** — when `verify_links` is enabled (default), broken URLs are detected after the LLM submits its output and sent back as an error tool result so the model can fix them and resubmit. (@jdx)

- **Parallel tool dispatch** — when the LLM issues multiple tool calls in a single turn, they now execute concurrently instead of sequentially. (#19, @jdx)

- **New agent tools** for richer repository context:
  - `get_issue` — fetch GitHub issue details (title, body, labels, state, author)
  - `git_show` — show full commit details including diff (with 50KB truncation)
  - `get_commits` — list commits between refs or filtered by file path
  (@jdx)

- **`emoji` config option** (default: `true`) — set to `false` to suppress all emoji in generated output. (@jdx)

- **`verify_links` config option** (default: `true`) — control whether URLs in output are checked for 404s. (@jdx)

- **`match_style` config option** (default: `true`) — when enabled, recent release notes are fetched and included as a style reference for the LLM. (@jdx)

- **Progress spinner with tool details** — the spinner now shows which specific tool is running (e.g. `Running tool: get_pr(#19)...`). (@jdx)

- **Structured release body template** — the system prompt now includes a detailed template with Highlights, What's Changed, Breaking Changes, New Contributors, and Full Changelog sections. (@jdx)

- **VitePress documentation site** with auto-generated CLI reference via `usage-lib`. (@jdx)

### Fixed

- **`previous_tag` falls back to the root commit** when no tags exist, enabling release notes generation for the very first release of a project. (@jdx)

- **`resolve_ref` no longer prints stderr** when a ref doesn't exist — uses `--quiet` flag and stderr capture for clean fallback behavior. (@jdx)

## Breaking Changes

- The `ANTHROPIC_API_KEY` environment variable is now only required when using the Anthropic provider. For OpenAI-compatible providers, set `OPENAI_API_KEY` or `LLM_API_KEY` instead.