### PR TITLE
The Agent Upgrade: Multi-Provider LLM, Smarter Tooling, and Resilient API Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,37 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API alongside Anthropic Claude via `--provider` and `--base-url` flags
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Automatic link verification in generated release notes, with the LLM agent able to fix broken URLs before final output
+- Emoji toggle (`emoji = true/false` in config) to suppress emoji in output
+- Style matching: automatically fetches recent releases and instructs the LLM to match their tone and formatting
+- New agent tools: `get_issue`, `git_show`, and `get_commits` for richer repository context
+- Parallel tool dispatch — multiple tool calls in a single LLM turn now execute concurrently
+- Retry with exponential backoff for transient API errors (429, 500, 502, 503, 529) with Retry-After header support
+- Progress spinner with detailed status updates throughout the generation process
+- Structured `submit_release_notes` tool call replaces free-form text parsing for reliable output
+- VitePress documentation site
 
-- Fix CI: run cargo test with mise for ripgrep on PATH
-- Add get_issue, git_show, and get_commits agent tools
-- Add retry with exponential backoff for API calls
-- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
-- Add generate.rs integration tests and extract shared test helpers
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Fixed
+- Previous tag detection now falls back to root commit when no tags exist (first release)
+- Non-tag refs (HEAD, branches, commit SHAs) now work as the current tag argument
+- TOML parse errors now show source spans via miette for easier debugging
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Fix CI: run cargo test with mise for ripgrep on PATH
+- Add get_issue, git_show, and get_commits agent tools
+- Add retry with exponential backoff for API calls
+- Parallelize tool dispatch in agent loop ([#19](https://github.com/jdx/communique/pull/19))
+- Add generate.rs integration tests and extract shared test helpers
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
This release transforms communiqué from a single-provider CLI into a flexible, multi-provider AI agent for generating release notes. It adds support for any OpenAI-compatible LLM, introduces dry-run mode, parallel tool execution, automatic link verification with self-healing, retry logic for transient API failures, and significantly expands the agent's ability to understand your repository.

## Highlights

- **Multi-model LLM support** — Use any OpenAI-compatible provider (GPT-4, Groq, Together, Ollama, etc.) alongside Anthropic Claude, with auto-detection from model name
- **Dry-run mode** — Preview generated release notes without publishing to GitHub or verifying links
- **Self-healing link verification** — The agent checks all URLs in its output and automatically fixes broken links before submitting
- **Retry with exponential backoff** — Transient API errors (rate limits, server errors) are automatically retried with Retry-After header support

## What's Changed

### Added

- **Multi-provider LLM support**: New `--provider` and `--base-url` CLI flags (and corresponding config fields) let you use any OpenAI-compatible API. Provider is auto-detected from model name (`claude*` → Anthropic, everything else → OpenAI). (@jdx)
  ```toml
  # communique.toml
  [defaults]
  provider = "openai"
  model = "gpt-4o"
  ```
- **Dry-run mode** (`--dry-run` / `-n`): Preview release notes locally without updating GitHub releases or verifying links. (@jdx)
- **Link verification in the agent loop**: URLs in generated notes are checked for 404s and broken links. If any are found, the agent is asked to fix or remove them and resubmit — no manual intervention needed. Controllable via `verify_links = true/false` in config. (@jdx)
- **Emoji toggle**: Set `emoji = false` in `communique.toml` to suppress all emoji in generated output. (@jdx)
- **Style matching**: Automatically fetches up to 2 recent releases and includes them as a style reference so the LLM matches your project's existing tone and formatting. Controllable via `match_style = true/false`. (@jdx)
- **New agent tools** — `get_issue`, `git_show`, and `get_commits` give the LLM richer context: issues explain motivation, commit details show exactly what changed, and commit listings help navigate history. (@jdx)
- **Parallel tool dispatch**: Multiple tool calls in a single LLM turn now execute concurrently using `futures_util::join_all`, speeding up iterations with multiple GitHub API calls. (@jdx in #19)
- **Retry with exponential backoff**: Transient errors (429 rate limits, 500/502/503/529 server errors, connection failures) on both LLM and GitHub API calls now trigger automatic retries with jitter. Respects `Retry-After` headers for 429 responses. (@jdx)
- **Progress spinner**: A live spinner with detailed status updates shows each phase — repo discovery, git log reading, context fetching, agent iterations with tool call details (e.g. `read_file(src/main.rs)`), link verification, and GitHub publishing. (@jdx)
- **Structured output via tool call**: The LLM now calls a `submit_release_notes` tool with structured `changelog`, `release_title`, and `release_body` fields, eliminating chain-of-thought leakage and fragile text parsing. (@jdx)
- **VitePress documentation site** with auto-generated CLI reference. (@jdx)

### Fixed

- **First-release support**: Previous tag detection now falls back to the root commit when no tags exist or the current tag is the earliest, so `communique generate v0.1.0` works on a brand-new repo. (@jdx)
- **Non-tag ref support**: HEAD, branch names, and commit SHAs now work as the tag argument — `previous_tag()` falls back to the most recent tag, and `log_between()` resolves refs before computing the range. (@jdx)
- **TOML parse errors**: Config file errors now display source spans with miette, showing exactly where the problem is in `communique.toml`. (@jdx)