### PR TITLE
v0.1.1: The Agent Awakens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+### Added
+- Multi-model LLM support with OpenAI-compatible providers — use any OpenAI-compatible API alongside Anthropic (`--provider`, `--base-url`)
+- New agent tools: `get_issue`, `git_show`, and `get_commits` for richer repository context
+- Dry-run mode (`--dry-run` / `-n`) to preview release notes without publishing or verifying links
+- Link verification in the agent loop — broken URLs are automatically detected and sent back to the model for correction
+- Retry with exponential backoff for all API calls (Anthropic, OpenAI, and GitHub)
+- `--verbose` and `--quiet` flags for controlling output verbosity
+- `--config` flag to specify a custom config file path
+- `--output` flag to write generated notes to a file
+- Text fallback parsing when the model returns prose instead of calling `submit_release_notes`
+- Progress indication via `clx` spinners and status messages
+- VitePress documentation site
+- Auto-generated CLI reference docs via `usage-lib`
 
-- Merge branch 'main' into pr-title-update
-- Fix CI: run cargo test with mise for ripgrep on PATH
-- Add integration tests, usage KDL sync check, and cargo audit in CI
-- Add --config flag to specify custom config file path
-- Fetch existing release and recent releases in parallel
-- Use Provider enum with strum/serde for config validation
-- Prefix release PR title with version tag
-- Add text fallback parsing when model skips submit_release_notes
-- Add --verbose and --quiet flags, replace env_logger with clx ProgressLogger
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+### Changed
+- Tool calls from a single LLM turn are now executed concurrently for faster generation
+- Existing release and recent releases are fetched in parallel
+- Provider is now a validated enum (`anthropic` / `openai`) with proper config validation via `strum`/`serde`
+
+### Fixed
+- `previous_tag` now falls back to the root commit when no tags exist
+- Non-tag git refs are now supported for the previous tag argument
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Merge branch 'main' into pr-title-update
+- Fix CI: run cargo test with mise for ripgrep on PATH
+- Add integration tests, usage KDL sync check, and cargo audit in CI
+- Add --config flag to specify custom config file path
+- Fetch existing release and recent releases in parallel
+- Use Provider enum with strum/serde for config validation
+- Prefix release PR title with version tag
+- Add text fallback parsing when model skips submit_release_notes
+- Add --verbose and --quiet flags, replace env_logger with clx ProgressLogger
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
This is the first feature release of communiqué, transforming it from a minimal proof-of-concept into a capable, multi-provider AI agent for generating release notes. v0.1.1 adds OpenAI-compatible LLM support, three new repository-browsing tools, link verification, retry logic, dry-run mode, and a much-improved CLI experience with progress spinners and verbosity controls.

## Highlights

- **Multi-provider LLM support** — Use any OpenAI-compatible API alongside Anthropic. Provider is auto-detected from the model name or set explicitly with `--provider` and `--base-url`.
- **Smarter agent loop** — Three new tools (`get_issue`, `git_show`, `get_commits`) give the AI deeper repository context. Tool calls are now executed concurrently for faster generation.
- **Link verification** — Generated release notes are automatically checked for broken URLs before being published. The model is asked to fix any broken links.
- **Dry-run mode** — Preview release notes with `--dry-run` / `-n` without publishing or verifying links.

## What's Changed

### Added
- Multi-model LLM support with OpenAI-compatible providers — use any OpenAI-compatible API alongside Anthropic via `--provider` and `--base-url` flags, or set defaults in `communique.toml` (@jdx)
- New agent tools for richer repository context: `get_issue` (fetch GitHub issue details), `git_show` (view commit details and diffs), and `get_commits` (list commits between refs or for a file path) (@jdx)
- Dry-run mode (`--dry-run` / `-n`) to preview generated release notes without publishing to GitHub or verifying links (@jdx)
- Automatic link verification in the agent loop — broken URLs in generated notes are detected and the model is prompted to fix them before final output (@jdx)
- Retry with exponential backoff for all API calls (Anthropic, OpenAI, and GitHub), including `Retry-After` header support for 429 responses (@jdx)
- `--verbose` and `--quiet` flags to control output verbosity, replacing the `RUST_LOG` environment variable (@jdx)
- `--config` flag to specify a custom config file path instead of the default `communique.toml` in the repo root (@jdx)
- `--output` / `-o` flag to write generated notes to a file instead of stdout (@jdx)
- Text fallback parsing when the model returns prose instead of calling the `submit_release_notes` tool (@jdx)
- Progress indication via `clx` spinners and status messages throughout the generation process (@jdx)
- Style matching — recent releases are fetched and included in the prompt so the model can match existing tone and formatting (@jdx)
- VitePress documentation site with auto-generated CLI reference docs via `usage-lib` (@jdx)

### Changed
- Tool calls from a single LLM turn are now executed concurrently using `futures-util` for faster generation (#19, @jdx)
- Existing release and recent releases are fetched in parallel via `tokio::join!` (@jdx)
- Provider is now a validated enum (`anthropic` / `openai`) using `strum`/`serde`, with proper config validation (@jdx)
- TOML config parse errors now display source-highlighted diagnostics via `miette` (@jdx)

### Fixed
- `previous_tag` now falls back to the root commit when no tags exist, fixing first-release scenarios (@jdx)
- Non-tag git refs (e.g. commit SHAs) are now supported as the previous tag argument (@jdx)