### PR TITLE
v0.1.1: Multi-Provider LLM Support, Dry-Run Mode, and Resilient Agent Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+### Other
+
+- Add in-memory cache for tool call results in agent loop
+- Use top-level ## headings for release note categories
+- Merge branch 'main' into pr-title-update
+- Fix CI: run cargo test with mise for ripgrep on PATH
+- Add integration tests, usage KDL sync check, and cargo audit in CI
+- Add --config flag to specify custom config file path
+- Fetch existing release and recent releases in parallel
+- Use Provider enum with strum/serde for config validation
+- Prefix release PR title with version tag
+- Add text fallback parsing when model skips submit_release_notes
+- Add --verbose and --quiet flags, replace env_logger with clx ProgressLogger
+- Add CLAUDE.md with project guidance for Claude Code
+- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
+- Add ripgrep to mise tools and remove has_rg guards from tests
+- Add agent loop edge case and link verification fallback tests
+- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
+- Rename lint workflow to CI and add cargo test
+- Add comprehensive test suite across all modules
+- Add mock LlmClient agent loop tests
+- Add multi-model LLM support with OpenAI-compatible provider
+- Add release body template, dry-run mode, and link verification in agent loop
+- Add link verification, emoji toggle, tool details, and prompt improvements
+- Add pkl to mise tools for hk config parsing in CI
+- Add hk to mise tools so it's available in CI
+- Use structured tool call for release notes output
+- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
+- Use debug builds and add Rust cache to release-plz workflow
+- Build communique from main before checking out PR branch
+- Fix previous_tag to fall back to root commit when no tags exist
+- Support non-tag refs and integrate communique into release-plz workflow
+- Add usage-lib for auto-generated CLI reference docs
+- Add progress indication via clx
+- Add README with roadmap
+- Add VitePress docs site with vaporwave theme
+- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,43 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
-### Other
+## Added
+- Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
+- `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
+- `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity
+- `--config` (`-c`) flag to specify a custom config file path
+- `--output` (`-o`) flag to write output to a file instead of stdout
+- Link verification: generated release notes are checked for broken URLs (404s), and the LLM is asked to fix them before finalizing
+- Emoji toggle via `emoji` config option (default: true) to suppress emoji in output
+- Automatic retry with exponential backoff for transient API failures (429, 500, 502, 503, 529) with Retry-After header support
+- New agent tools: `get_issue`, `git_show`, and `get_commits` for richer repository context
+- In-memory cache for tool call results to avoid redundant API calls
+- Text fallback parsing when the LLM skips the `submit_release_notes` tool call
+- Style matching: fetches recent releases to guide the LLM on tone and formatting
+- Parallel tool dispatch in the agent loop for faster multi-tool iterations
+- Parallel fetching of existing release and recent releases during context gathering
+- Progress indication showing detailed tool call info (e.g. `read_file(src/main.rs)`)
 
-- Add in-memory cache for tool call results in agent loop
-- Use top-level ## headings for release note categories
-- Merge branch 'main' into pr-title-update
-- Fix CI: run cargo test with mise for ripgrep on PATH
-- Add integration tests, usage KDL sync check, and cargo audit in CI
-- Add --config flag to specify custom config file path
-- Fetch existing release and recent releases in parallel
-- Use Provider enum with strum/serde for config validation
-- Prefix release PR title with version tag
-- Add text fallback parsing when model skips submit_release_notes
-- Add --verbose and --quiet flags, replace env_logger with clx ProgressLogger
-- Add CLAUDE.md with project guidance for Claude Code
-- Add code coverage to CI ([#22](https://github.com/jdx/communique/pull/22))
-- Add ripgrep to mise tools and remove has_rg guards from tests
-- Add agent loop edge case and link verification fallback tests
-- Update release PR title with communique output ([#23](https://github.com/jdx/communique/pull/23))
-- Rename lint workflow to CI and add cargo test
-- Add comprehensive test suite across all modules
-- Add mock LlmClient agent loop tests
-- Add multi-model LLM support with OpenAI-compatible provider
-- Add release body template, dry-run mode, and link verification in agent loop
-- Add link verification, emoji toggle, tool details, and prompt improvements
-- Add pkl to mise tools for hk config parsing in CI
-- Add hk to mise tools so it's available in CI
-- Use structured tool call for release notes output
-- Add hk for pre-commit hooks, lint CI, miette TOML errors, and resolve_ref fallback
-- Use debug builds and add Rust cache to release-plz workflow
-- Build communique from main before checking out PR branch
-- Fix previous_tag to fall back to root commit when no tags exist
-- Support non-tag refs and integrate communique into release-plz workflow
-- Add usage-lib for auto-generated CLI reference docs
-- Add progress indication via clx
-- Add README with roadmap
-- Add VitePress docs site with vaporwave theme
-- release v0.1.0 ([#3](https://github.com/jdx/communique/pull/3))
+## Changed
+- Provider is auto-detected from model name (`claude*` → Anthropic, everything else → OpenAI)
+- Link verification now runs inside the agent loop so the LLM can fix broken URLs and resubmit
+- Release body template updated with structured sections (Highlights, Breaking Changes, New Contributors, Full Changelog)
+- Replaced `env_logger` with integrated `clx` ProgressLogger for cleaner log output alongside progress spinners
+
+## Fixed
+- `previous_tag` now falls back to the root commit when no tags exist
+- `resolve_ref` suppresses stderr output when a ref doesn't exist
 
 ## [0.1.0](https://github.com/jdx/communique/releases/tag/v0.1.0) - 2026-02-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.1 is a significant feature release that transforms the tool from an Anthropic-only CLI into a multi-provider AI release note generator with a much more resilient and capable agent loop. This release adds support for any OpenAI-compatible LLM provider, introduces dry-run mode, and makes the tool substantially more reliable with automatic retries, text fallback parsing, and in-agent link verification.

## Highlights

- **Multi-provider LLM support** — Use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API alongside Anthropic. Provider is auto-detected from the model name, or set explicitly with `--provider` and `--base-url`.
- **Dry-run mode** — Preview generated release notes with `--dry-run` (`-n`) without publishing to GitHub or verifying links.
- **Automatic retry with backoff** — Transient API failures (429 rate limits, 5xx server errors) now retry automatically with exponential backoff and `Retry-After` header support.
- **Parallel tool execution** — When the LLM requests multiple tools in a single turn, they now execute concurrently for significantly faster iterations.

## Added

- Multi-model LLM support with an `LlmClient` trait abstracting provider differences. Use `--provider anthropic|openai` and `--base-url` to target any compatible API (@jdx)
  ```sh
  # Use OpenAI
  communique generate v1.0.0 --model gpt-4o --provider openai

  # Use a local Ollama instance
  communique generate v1.0.0 --model llama3 --base-url $OLLAMA_URL/v1
  ```
- `--dry-run` (`-n`) flag to generate notes without updating GitHub or verifying links (@jdx)
- `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity — replaces the need for `RUST_LOG` env var (@jdx)
- `--config` (`-c`) flag to specify a custom config file path (@jdx)
- `--output` (`-o`) flag to write output to a file instead of stdout (@jdx)
- Link verification inside the agent loop — broken URLs are reported back to the LLM, which fixes them and resubmits (@jdx)
- `emoji` config option (default: `true`) to suppress emoji in generated output (@jdx)
- `verify_links` config option (default: `true`) to control link checking (@jdx)
- `match_style` config option (default: `true`) — fetches recent releases to guide the LLM on tone and formatting (@jdx)
- Automatic retry with exponential backoff for transient API failures (429, 500, 502, 503, 529) with `Retry-After` header support — applies to both LLM and GitHub API calls (@jdx)
- New agent tools: `get_issue`, `git_show`, and `get_commits` give the LLM richer repository context (@jdx)
- In-memory cache for tool call results to avoid redundant API calls (@jdx)
- Text fallback parsing when the LLM ends its turn without calling `submit_release_notes` — the agent extracts a title and body from raw text instead of erroring (@jdx)
- Parallel tool dispatch in the agent loop using `futures-util` for faster multi-tool iterations (#19, @jdx)
- Parallel fetching of existing release and recent releases during context gathering (@jdx)
- Config validation: `max_tokens` must be > 0, `provider` must be `anthropic` or `openai`, and `repo` must be in `owner/repo` format (@jdx)
- Structured release body template with Highlights, Breaking Changes, New Contributors, and Full Changelog sections (@jdx)
- Progress indicator now shows detailed tool call info (e.g. `read_file(src/main.rs)`) (@jdx)

## Changed

- Provider is auto-detected from model name (`claude*` → Anthropic, everything else → OpenAI) (@jdx)
- `Provider` is now a proper enum with `strum`/`serde` derives — invalid values are rejected at config load and CLI parse time (@jdx)
- Replaced `env_logger` with `clx` ProgressLogger for cleaner log output integrated with progress spinners (@jdx)

## Fixed

- `previous_tag` now falls back to the root commit when no tags exist, so the first release captures full history instead of erroring (@jdx)
- `resolve_ref` suppresses stderr when a ref doesn't exist (@jdx)