### PR TITLE
Debug rg CI failure and remove dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@cargo-audit
       - run: mise run lint
-      - name: Debug rg
-        run: |
-          which rg
-          rg --version
-          echo "hello world" > /tmp/rg-test.txt
-          rg hello /tmp/rg-test.txt
       - run: mise x -- cargo test
       - run: cargo audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - uses: jdx/mise-action@v2
+      - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@cargo-audit
       - run: mise run lint
+      - name: Debug rg
+        run: |
+          which rg
+          rg --version
+          echo "hello world" > /tmp/rg-test.txt
+          rg hello /tmp/rg-test.txt
       - run: mise x -- cargo test
       - run: cargo audit
 
@@ -25,11 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - uses: jdx/mise-action@v2
+      - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: mise x -- cargo llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run release-plz
         id: release-plz
@@ -81,8 +79,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run release-plz
         id: release-plz

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.1"
+version "0.1.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,7 @@ run = "hk check --all"
 dir = "docs"
 run = "npm i && exec npm run docs:dev"
 
+# rust is managed by rustup, not mise
 [tools]
 hk = "latest"
 pkl = "latest"

--- a/src/tools/grep.rs
+++ b/src/tools/grep.rs
@@ -80,19 +80,6 @@ mod tests {
         repo.write_file("hello.txt", "hello world\nfoo bar");
         repo.commit("init");
 
-        // Debug: verify file exists and rg is available
-        let dir = repo.path();
-        let content = std::fs::read_to_string(dir.join("hello.txt")).unwrap();
-        eprintln!("repo_root: {}", dir.display());
-        eprintln!("hello.txt content: {content:?}");
-        let rg_version = std::process::Command::new("rg").arg("--version").output();
-        eprintln!("rg --version: {rg_version:?}");
-        let rg_direct = std::process::Command::new("rg")
-            .args(["--no-config", "hello"])
-            .current_dir(dir)
-            .output();
-        eprintln!("rg hello (direct): {rg_direct:?}");
-
         let result = execute(repo.path(), &json!({"pattern": "hello"})).unwrap();
         assert!(
             result.contains("hello world"),

--- a/src/tools/grep.rs
+++ b/src/tools/grep.rs
@@ -80,6 +80,19 @@ mod tests {
         repo.write_file("hello.txt", "hello world\nfoo bar");
         repo.commit("init");
 
+        // Debug: verify file exists and rg is available
+        let dir = repo.path();
+        let content = std::fs::read_to_string(dir.join("hello.txt")).unwrap();
+        eprintln!("repo_root: {}", dir.display());
+        eprintln!("hello.txt content: {content:?}");
+        let rg_version = std::process::Command::new("rg").arg("--version").output();
+        eprintln!("rg --version: {rg_version:?}");
+        let rg_direct = std::process::Command::new("rg")
+            .args(["--no-config", "hello"])
+            .current_dir(dir)
+            .output();
+        eprintln!("rg hello (direct): {rg_direct:?}");
+
         let result = execute(repo.path(), &json!({"pattern": "hello"})).unwrap();
         assert!(
             result.contains("hello world"),


### PR DESCRIPTION
## Summary
- Remove `dtolnay/rust-toolchain` from ci.yml and release-plz.yml (ubuntu runners have rust pre-installed via rustup)
- Use `rustup component add` directly for clippy/rustfmt/llvm-tools-preview
- Add `rg --version` / `which rg` debug step to CI
- Add diagnostic eprintln to `test_grep_basic` to capture rg behavior in CI

## Test plan
- [ ] Check CI logs for rg debug output to understand why rg returns "No matches found." in temp repos
- [ ] Verify rust toolchain still works without dtolnay action

🤖 Generated with [Claude Code](https://claude.com/claude-code)