### PR TITLE
v0.1.2: v0.1.2: Tag-Prefixed Release Titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
+
+### Other
+
+- Prefix release titles with tag and use draft releases
+
 ## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"


### PR DESCRIPTION
communiqué v0.1.2 is a small patch release that automatically prefixes generated release titles with the version tag for clearer identification in GitHub's release list.

## Changed

- Release titles are now automatically prefixed with the tag (e.g. `v0.1.2: My Release Title`) when the title doesn't already start with the tag. This makes it easier to identify versions at a glance in GitHub's releases page. (@jdx)