### PR TITLE
v0.1.3: v0.1.3: Fix draft release lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+
+### Other
+
+- Fix draft release lookup and update docs
+
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
-### Other
+### Fixed
 
-- Fix draft release lookup and update docs
+- Draft releases can now be found by tag — `get_release_by_tag` falls back to listing releases when the `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases
+
+### Changed
+
+- Updated GitHub Actions documentation to show `--changelog` usage, the required `git fetch --tags` step, and simplified workflow examples
 
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
@@ -19,9 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefix release titles with tag and use draft releases
 
-## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
-
-## Added
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1)## Added
 - Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
 - `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
 - `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.1"
+version "0.1.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true


### PR DESCRIPTION
A small patch release that fixes communiqué's inability to find draft releases (e.g. those created by release-plz) and improves the GitHub Actions documentation.

## Fixed

- **Draft release lookup** — `get_release_by_tag` now falls back to listing releases when the GitHub `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases. This fixes communiqué failing to update releases created by tools like release-plz that use draft releases. (@jdx)

## Changed

- Updated GitHub Actions docs to show `--changelog` usage, added the required `git fetch --tags` step (needed because release-plz creates tags via the GitHub API, so they aren't in the local checkout), and simplified the workflow examples (@jdx)