### PR TITLE
v0.1.3: v0.1.3: Fix draft release handling and improve agent reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
-### Other
+### Fixed
+- Draft releases are now correctly found and updated — `get_release_by_tag` falls back to listing releases when the `/releases/tags` endpoint returns 404 ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
+- Grep agent tool switched from `xx::process` to `std::process::Command` for more reliable behavior in CI and other environments ([#34](https://github.com/jdx/communique/pull/34))
 
-- Debug rg CI failure and remove dtolnay/rust-toolchain ([#34](https://github.com/jdx/communique/pull/34))
-- Remove macOS x86_64 from release matrix
-- Fix draft release lookup and update docs
+### Changed
+- Pre-built macOS x86_64 binary is no longer published in releases ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))
+- GitHub Actions documentation updated with `--changelog` usage examples and required `git fetch --tags` step ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
 
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
@@ -21,9 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefix release titles with tag and use draft releases
 
-## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
-
-## Added
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12## Added
 - Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
 - `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
 - `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+
+### Other
+
+- Debug rg CI failure and remove dtolnay/rust-toolchain ([#34](https://github.com/jdx/communique/pull/34))
+- Remove macOS x86_64 from release matrix
+- Fix draft release lookup and update docs
+
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.2"
+version "0.1.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true


### PR DESCRIPTION
communiqué v0.1.3 is a small patch that fixes an issue where draft releases couldn't be found and updated, improves the reliability of the grep tool used by the AI agent, and updates documentation.

## Fixed

- **Draft release lookup** — `get_release_by_tag` now falls back to listing releases when the GitHub `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases. Previously, communiqué would fail to update draft releases created by release-plz. (@jdx in [f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
- **Grep tool reliability** — The agent's `grep` tool switched from the `xx::process` crate to `std::process::Command` for more reliable subprocess handling across environments. (@jdx in [#34](https://github.com/jdx/communique/pull/34))

## Changed

- **macOS x86_64 binary dropped** — Pre-built binaries for macOS x86_64 (Intel) are no longer published. macOS aarch64 (Apple Silicon) binaries continue to be available and work on Intel Macs via Rosetta 2. (@jdx in [2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))
- **Updated GitHub Actions docs** — Documentation now shows `--changelog` usage and includes the required `git fetch --tags` step when using communiqué with release-plz. (@jdx in [f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))