### PR TITLE
Fix double tag prefix in PR titles

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -110,7 +110,7 @@ jobs:
           FULL_NOTES=$($COMMUNIQUE generate "$TAG" --changelog)
 
           # Update PR title and body with full release notes
-          PR_TITLE="$TAG: $(echo "$FULL_NOTES" | head -1 | sed 's/^# //')"
+          PR_TITLE=$(echo "$FULL_NOTES" | head -1 | sed 's/^# //')
           PR_BODY=$(echo "$FULL_NOTES" | tail -n +3)
           gh pr edit "$PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
 

--- a/docs/guide/github-actions.md
+++ b/docs/guide/github-actions.md
@@ -140,7 +140,7 @@ Use `--changelog` to update `CHANGELOG.md` with AI-generated notes and update th
           NOTES=$(communique generate "$TAG" --changelog)
 
           # Update PR title and body
-          PR_TITLE="$TAG: $(echo "$NOTES" | head -1 | sed 's/^# //')"
+          PR_TITLE=$(echo "$NOTES" | head -1 | sed 's/^# //')
           PR_BODY=$(echo "$NOTES" | tail -n +3)
           gh pr edit "$PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
 


### PR DESCRIPTION
## Summary
- The workflow was prepending `$TAG:` to the PR title, but `generate.rs` already prefixes `release_title` with the tag, resulting in `v0.1.3: v0.1.3: ...`
- Remove the redundant `$TAG:` prefix from the workflow and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)