### PR TITLE
v0.1.3: Draft release fix and workflow cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
-### Other
+### Fixed
+- Fix draft release lookup — `get_release_by_tag` now falls back to listing releases when the `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
+- Fix double tag prefix in PR titles where the workflow and `generate.rs` both prepended the tag, resulting in `v0.1.3: v0.1.3: ...` ([#39](https://github.com/jdx/communique/pull/39))
 
-- Fix double tag prefix in PR titles ([#39](https://github.com/jdx/communique/pull/39))
-- Debug rg CI failure and remove dtolnay/rust-toolchain ([#34](https://github.com/jdx/communique/pull/34))
-- Remove macOS x86_64 from release matrix
-- Fix draft release lookup and update docs
+### Changed
+- Updated GitHub Actions documentation to show `--changelog` usage, the required `git fetch --tags` step, and simplified workflow examples ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
+
+### Removed
+- macOS x86_64 pre-built binaries are no longer published; only aarch64 (Apple Silicon) binaries are provided for macOS ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))
 
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
@@ -22,9 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefix release titles with tag and use draft releases
 
-## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
-
-## Added
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12## Added
 - Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
 - `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
 - `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/jdx/communique/compare/v0.1.2...v0.1.3) - 2026-02-12
+
+### Other
+
+- Fix double tag prefix in PR titles ([#39](https://github.com/jdx/communique/pull/39))
+- Debug rg CI failure and remove dtolnay/rust-toolchain ([#34](https://github.com/jdx/communique/pull/34))
+- Remove macOS x86_64 from release matrix
+- Fix draft release lookup and update docs
+
 ## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.2"
+version "0.1.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true


### PR DESCRIPTION
A small bugfix release that fixes communiqué's ability to find and update draft GitHub releases, corrects a doubled tag prefix in PR titles, and drops macOS x86_64 binaries from the release matrix.

## Fixed

- **Draft release lookup** — `get_release_by_tag` now falls back to listing releases when the `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases. This fixes scenarios where communiqué couldn't find a release created as a draft. ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176)) (@jdx)
- **Double tag prefix in PR titles** — The CI workflow was prepending `$TAG:` to the PR title, but `generate.rs` already includes the tag in the release title, resulting in titles like `v0.1.3: v0.1.3: ...`. The redundant prefix has been removed from the workflow and docs. ([#39](https://github.com/jdx/communique/pull/39)) (@jdx)

## Changed

- Updated GitHub Actions documentation to show `--changelog` usage, the required `git fetch --tags` step, and cleaner workflow examples. ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176)) (@jdx)

## Removed

- **macOS x86_64 binaries** are no longer published. Only aarch64 (Apple Silicon) pre-built binaries are provided for macOS. macOS x86_64 users can still install via `cargo install`. ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38)) (@jdx)