### PR TITLE
Increase retry patience and make communique non-fatal in CI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -110,7 +110,7 @@ jobs:
           FULL_NOTES=$($COMMUNIQUE generate "$TAG" --changelog)
 
           # Update PR title and body with full release notes
-          PR_TITLE="$TAG: $(echo "$FULL_NOTES" | head -1 | sed 's/^# //')"
+          PR_TITLE=$(echo "$FULL_NOTES" | head -1 | sed 's/^# //')
           PR_BODY=$(echo "$FULL_NOTES" | tail -n +3)
           gh pr edit "$PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,6 +33,7 @@ jobs:
         run: git fetch --tags
       - name: Enhance GitHub release with communique
         if: steps.release-plz.outputs.releases_created == 'true'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -89,6 +90,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Update release PR
         if: steps.release-plz.outputs.prs_created == 'true'
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/docs/guide/github-actions.md
+++ b/docs/guide/github-actions.md
@@ -140,7 +140,7 @@ Use `--changelog` to update `CHANGELOG.md` with AI-generated notes and update th
           NOTES=$(communique generate "$TAG" --changelog)
 
           # Update PR title and body
-          PR_TITLE="$TAG: $(echo "$NOTES" | head -1 | sed 's/^# //')"
+          PR_TITLE=$(echo "$NOTES" | head -1 | sed 's/^# //')
           PR_BODY=$(echo "$NOTES" | tail -n +3)
           gh pr edit "$PR_NUMBER" --title "$PR_TITLE" --body "$PR_BODY"
 

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -3,9 +3,9 @@ use std::time::{Duration, SystemTime};
 
 use crate::error::Result;
 
-const MAX_RETRIES: u32 = 5;
-const INITIAL_DELAY_MS: u64 = 500;
-const MAX_DELAY_MS: u64 = 30_000;
+const MAX_RETRIES: u32 = 10;
+const INITIAL_DELAY_MS: u64 = 1_000;
+const MAX_DELAY_MS: u64 = 60_000;
 
 pub struct RetryConfig {
     pub max_retries: u32,


### PR DESCRIPTION
## Summary
- Bump retry from 5 attempts / 500ms initial / 30s max to 10 attempts / 1s initial / 60s max for better resilience against transient API outages (like the Anthropic 529 in #37)
- Add `continue-on-error: true` to both communique steps in the release workflow so failures don't block releases or PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)