### PR TITLE
v0.1.4: More patient retries for flaky APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/jdx/communique/compare/v0.1.3...v0.1.4) - 2026-02-12
+
+### Other
+
+- Increase retry patience and make communique non-fatal in CI ([#41](https://github.com/jdx/communique/pull/41))
+
 ## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.4](https://github.com/jdx/communique/compare/v0.1.3...v0.1.4) - 2026-02-12
+## [0.1.4](https://github.com/jdx/communique/releases/tag/v0.1.4) - 2026-02-12
 
-### Other
+### Changed
+- Increased retry resilience for transient API failures — retries now use 10 attempts with a 1s initial delay and 60s max backoff (up from 5 attempts / 500ms / 30s), improving reliability during API outages ([#41](https://github.com/jdx/communique/pull/41))
 
-- Increase retry patience and make communique non-fatal in CI ([#41](https://github.com/jdx/communique/pull/41))
+### Fixed
+- Fixed double tag prefix in release PR titles where both the workflow and generate logic prepended the tag ([#41](https://github.com/jdx/communique/pull/41))
 
 ## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
@@ -29,9 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Prefix release titles with tag and use draft releases
-
-## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12## Added
+- Prefix release titles with tag and use draft releases## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12## Added
 - Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
 - `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
 - `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.3"
+version "0.1.4"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true


### PR DESCRIPTION
A small reliability patch that makes communique more resilient to transient API outages (like the Anthropic 529 errors seen in #37) by significantly increasing retry patience.

## Changed
- Increased retry resilience for transient API failures — retries now use 10 attempts with a 1s initial delay and 60s max backoff, up from the previous 5 attempts / 500ms / 30s configuration. This makes communique much more tolerant of temporary service disruptions. ([#41](https://github.com/jdx/communique/pull/41)) (@jdx)

## Fixed
- Fixed double tag prefix in release PR titles in the workflow examples and docs, where both the shell script and `generate` prepended the tag resulting in titles like `v0.1.3: v0.1.3: ...` ([#41](https://github.com/jdx/communique/pull/41)) (@jdx)