### PR TITLE
v0.1.5: Documentation sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/jdx/communique/compare/v0.1.4...v0.1.5) - 2026-02-12
+
+### Other
+
+- Add autofix CI workflow ([#43](https://github.com/jdx/communique/pull/43))
+
 ## [0.1.4](https://github.com/jdx/communique/releases/tag/v0.1.4) - 2026-02-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.5](https://github.com/jdx/communique/compare/v0.1.4...v0.1.5) - 2026-02-12
+## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
 
-### Other
-
-- Add autofix CI workflow ([#43](https://github.com/jdx/communique/pull/43))
+### Changed
+- Regenerated CLI documentation to reflect flags and options added in prior releases ([#43](https://github.com/jdx/communique/pull/43))
 
 ## [0.1.4](https://github.com/jdx/communique/releases/tag/v0.1.4) - 2026-02-12
 
@@ -31,9 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated GitHub Actions documentation to show `--changelog` usage, the required `git fetch --tags` step, and simplified workflow examples ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
 
 ### Removed
-- macOS x86_64 pre-built binaries are no longer published; only aarch64 (Apple Silicon) binaries are provided for macOS ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))
-
-## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
+- macOS x86_64 pre-built binaries are no longer published; only aarch64 (Apple Silicon) binaries are provided for macOS ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
 ### Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.4"
+version "0.1.5"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.4
+**Version**: 0.1.5
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A housekeeping release with no user-facing code changes. The auto-generated CLI documentation (`docs/cli/`) has been re-rendered to reflect flags and options (like `--changelog`, `--dry-run`, `--provider`, `--base-url`, `--output`, and global flags) that were added in previous versions but hadn't been synced to the docs.

## Changed
- Regenerated CLI documentation to accurately reflect all current flags and options ([#43](https://github.com/jdx/communique/pull/43)) (@jdx)