### PR TITLE
Fix draft release tags getting untagged-* placeholder

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -31,6 +31,20 @@ jobs:
       - name: Fetch new tags
         if: steps.release-plz.outputs.releases_created == 'true'
         run: git fetch --tags
+      - name: Fix draft release tags
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+        run: |
+          # Draft releases created before the tag exists get an "untagged-*" tag_name.
+          # Patch each draft release to use the correct tag.
+          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[].tag'); do
+            release_id=$(gh api repos/${{ github.repository }}/releases --jq ".[] | select(.draft and (.tag_name | startswith(\"untagged-\"))) | select(.name | startswith(\"${tag}\")) | .id" 2>/dev/null || true)
+            if [ -n "$release_id" ]; then
+              echo "Fixing draft release $release_id: setting tag_name to $tag"
+              gh api repos/${{ github.repository }}/releases/$release_id --method PATCH --field tag_name="$tag"
+            fi
+          done
       - name: Enhance GitHub release with communique
         if: steps.release-plz.outputs.releases_created == 'true'
         continue-on-error: true


### PR DESCRIPTION
## Summary
- When release-plz creates a draft release before the git tag exists, GitHub assigns an `untagged-*` placeholder as the `tag_name`
- This caused `taiki-e/upload-rust-binary-action` to fail with "release not found" (seen in v0.1.4 and v0.1.5)
- Adds a step after release-plz that patches any untagged draft releases with the correct `tag_name` via the GitHub API

## Test plan
- [x] Confirmed the issue is reproducible (v0.1.4 and v0.1.5 both got `untagged-*`)
- [x] Manually fixed v0.1.4 and v0.1.5 via `gh api --method PATCH` — upload-assets succeeded after fix
- [ ] Next release should automatically fix the tag before upload-assets runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)