### PR TITLE
v0.1.6: Fix pre-built binary uploads for releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/jdx/communique/compare/v0.1.5...v0.1.6) - 2026-02-12
+
+### Other
+
+- Fix draft release tags getting untagged-* placeholder ([#45](https://github.com/jdx/communique/pull/45))
+
 ## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/jdx/communique/compare/v0.1.5...v0.1.6) - 2026-02-12
+## [0.1.6](https://github.com/jdx/communique/releases/tag/v0.1.6) - 2026-02-12
 
-### Other
-
-- Fix draft release tags getting untagged-* placeholder ([#45](https://github.com/jdx/communique/pull/45))
+### Fixed
+- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45))
 
 ## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
 
@@ -24,9 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased retry resilience for transient API failures — retries now use 10 attempts with a 1s initial delay and 60s max backoff (up from 5 attempts / 500ms / 30s), improving reliability during API outages ([#41](https://github.com/jdx/communique/pull/41))
 
 ### Fixed
-- Fixed double tag prefix in release PR titles where both the workflow and generate logic prepended the tag ([#41](https://github.com/jdx/communique/pull/41))
-
-## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
+- Fixed double tag prefix in release PR titles where both the workflow and generate logic prepended the tag ([#41](https://github.com/jdx/communique/pull/41))## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
 ### Fixed
 - Fix draft release lookup — `get_release_by_tag` now falls back to listing releases when the `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.5"
+version "0.1.6"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.5",
+  "version": "0.1.6",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.5
+**Version**: 0.1.6
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that fixes an issue where pre-built binaries were not being attached to GitHub releases. When `release-plz` created a draft release before the git tag existed, GitHub assigned an `untagged-*` placeholder as the tag name, causing the binary upload step to fail with "release not found" (this affected v0.1.4 and v0.1.5).

### Fixed
- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45)) (@jdx)