### PR TITLE
Fix draft release tag fix failing due to API eventual consistency

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,11 +38,25 @@ jobs:
         run: |
           # Draft releases created before the tag exists get an "untagged-*" tag_name.
           # Patch each draft release to use the correct tag.
+          # Retry because the GitHub API may not immediately list the new release.
           for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[].tag'); do
-            release_id=$(gh api repos/${{ github.repository }}/releases --jq ".[] | select(.draft and (.tag_name | startswith(\"untagged-\"))) | select(.name | startswith(\"${tag}\")) | .id" 2>/dev/null || true)
+            echo "Looking for untagged draft release to fix for tag: $tag"
+            release_id=""
+            for attempt in $(seq 1 10); do
+              release_id=$(gh api repos/${{ github.repository }}/releases \
+                --jq ".[] | select(.draft and (.tag_name | startswith(\"untagged-\"))) | select(.name | contains(\"${tag}\")) | .id" \
+                | head -1) || true
+              if [ -n "$release_id" ]; then
+                break
+              fi
+              echo "  Attempt $attempt/10: untagged draft not found yet, retrying in 5s..."
+              sleep 5
+            done
             if [ -n "$release_id" ]; then
               echo "Fixing draft release $release_id: setting tag_name to $tag"
               gh api repos/${{ github.repository }}/releases/$release_id --method PATCH --field tag_name="$tag"
+            else
+              echo "::warning::No untagged draft release found for $tag after 10 attempts"
             fi
           done
       - name: Enhance GitHub release with communique

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -79,6 +79,7 @@ async fn test_generate_end_to_end() {
         ])
         .env("OPENAI_API_KEY", "test-key")
         .env("CLX_NO_PROGRESS", "1")
+        .env_remove("GITHUB_TOKEN")
         .output()
         .expect("failed to run communique");
 
@@ -168,6 +169,7 @@ async fn test_generate_concise() {
         ])
         .env("OPENAI_API_KEY", "test-key")
         .env("CLX_NO_PROGRESS", "1")
+        .env_remove("GITHUB_TOKEN")
         .output()
         .expect("failed to run communique");
 


### PR DESCRIPTION
## Summary

- The v0.1.6 release failed because all "Upload assets" jobs got `release not found` — the draft release still had an `untagged-*` tag_name instead of `v0.1.6`
- Root cause: the "Fix draft release tags" step ran ~0.5s after release-plz created the draft, hitting a GitHub API eventual consistency window where the new release wasn't yet returned by the list endpoint
- The `2>/dev/null || true` silently swallowed the failure, making it look like the step succeeded

### Changes
- Replace the single-shot API call with a retry loop (10 attempts, 5s apart)
- Remove `2>/dev/null` so errors are visible
- Switch `startswith` to `contains` for more flexible name matching
- Add logging so we can see what's happening in CI

## Test plan

- [x] Manually patched the stale v0.1.6 draft release tag and re-ran failed upload-assets jobs
- [ ] Verify next release successfully fixes the draft tag and uploads binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)