### PR TITLE
fix: propagate list releases error in get_release_by_tag fallback

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -104,10 +104,8 @@ impl GitHubClient {
 
         // Fall back to listing releases — the /releases/tags endpoint
         // doesn't return draft releases, but the list endpoint does.
-        match self.list_recent_releases(10).await {
-            Ok(releases) => Ok(releases.into_iter().find(|r| r.tag_name == tag)),
-            Err(_) => Ok(None),
-        }
+        let releases = self.list_recent_releases(10).await?;
+        Ok(releases.into_iter().find(|r| r.tag_name == tag))
     }
 
     pub async fn update_release(


### PR DESCRIPTION
## Summary

- The draft release fallback (`GET /releases?per_page=10`) was using `Err(_) => Ok(None)`, silently discarding any error from the list endpoint
- This meant if the list call failed for any reason (permissions, rate limit, network), `get_release_by_tag` would return `None` as if the release didn't exist — with no visible error
- Now propagates the error so callers see what actually went wrong

## Context

This was discovered while debugging why `communique generate v2.17.4 --github-release` printed "No GitHub release found for v2.17.4 — skipping update" despite the release existing as a draft. The silent error suppression made the root cause impossible to diagnose from logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)