### PR TITLE
v0.1.8: Better error reporting & more resilient CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.8](https://github.com/jdx/communique/compare/v0.1.7...v0.1.8) - 2026-02-18
+## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
 
 ### Added
 
-- extract communique into separate enhance-release job ([#51](https://github.com/jdx/communique/pull/51))
+- Extracted communique into a separate `enhance-release` CI job that runs after publish, making it independently re-runnable and removing `continue-on-error` so failures are visible ([#51](https://github.com/jdx/communique/pull/51))
 
 ### Fixed
 
-- propagate list releases error in get_release_by_tag fallback ([#49](https://github.com/jdx/communique/pull/49))
+- Propagated errors from the list releases API call in the `get_release_by_tag` fallback instead of silently swallowing them, fixing misleading "No GitHub release found" messages ([#49](https://github.com/jdx/communique/pull/49))
 
 ## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
 
@@ -26,9 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6](https://github.com/jdx/communique/releases/tag/v0.1.6) - 2026-02-12
 
 ### Fixed
-- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45))
-
-## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
+- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45))## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
 
 ### Changed
 - Regenerated CLI documentation to reflect flags and options added in prior releases ([#43](https://github.com/jdx/communique/pull/43))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/jdx/communique/compare/v0.1.7...v0.1.8) - 2026-02-18
+
+### Added
+
+- extract communique into separate enhance-release job ([#51](https://github.com/jdx/communique/pull/51))
+
+### Fixed
+
+- propagate list releases error in get_release_by_tag fallback ([#49](https://github.com/jdx/communique/pull/49))
+
 ## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "communique"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.7"
+version "0.1.8"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.7",
+  "version": "0.1.8",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.7
+**Version**: 0.1.8
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small release with a bug fix for silent error suppression in the GitHub release lookup and an improvement to how communique runs in its own CI pipeline.

### Fixed

- **Propagate errors in `get_release_by_tag` fallback** — The draft release fallback (`GET /releases?per_page=10`) was silently discarding errors (`Err(_) => Ok(None)`), which meant failures from permissions issues, rate limits, or network errors would surface as a misleading "No GitHub release found" message instead of the actual error. Errors are now properly propagated. ([#49](https://github.com/jdx/communique/pull/49)) (@jdx)

### Added

- **Separate `enhance-release` CI job** — Moved `communique generate` out of `release-plz-release` into a dedicated `enhance-release` job that runs after the release is published. This means it can be re-run independently from the GitHub Actions UI if it fails (e.g. due to Anthropic rate limits), and failures are now visible since `continue-on-error: true` has been removed. ([#51](https://github.com/jdx/communique/pull/51)) (@jdx)

**Full Changelog**: https://github.com/jdx/communique/compare/3f72ea8...b511ef6