### PR TITLE
v0.1.9: Consistent Release Title Formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/jdx/communique/compare/v0.1.8...v0.1.9) - 2026-03-02
+
+### Fixed
+
+- *(deps)* update rust crate strum to 0.28.0 ([#62](https://github.com/jdx/communique/pull/62))
+- *(deps)* update rust crate reqwest to 0.13 ([#57](https://github.com/jdx/communique/pull/57))
+- normalize release title to "vX.Y.Z: description" format ([#55](https://github.com/jdx/communique/pull/55))
+
+### Other
+
+- *(deps)* lock file maintenance ([#63](https://github.com/jdx/communique/pull/63))
+- *(deps)* update dependency vue to v3.5.29 ([#61](https://github.com/jdx/communique/pull/61))
+- *(deps)* lock file maintenance ([#60](https://github.com/jdx/communique/pull/60))
+- *(deps)* update rust crate clap to v4.5.60 ([#59](https://github.com/jdx/communique/pull/59))
+- *(deps)* pin dependencies ([#58](https://github.com/jdx/communique/pull/58))
+- *(deps)* update rust crate futures-util to v0.3.32 ([#56](https://github.com/jdx/communique/pull/56))
+- run render and lint-fix when creating release PR ([#53](https://github.com/jdx/communique/pull/53))
+
 ## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.8"
+version "0.1.9"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.8",
+  "version": "0.1.9",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.8
+**Version**: 0.1.9
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that fixes inconsistent release title formatting. Previously, if the LLM returned a title like `v2.18.0 (Internal CI improvements)` or `v2.18.0 - Internal CI improvements`, it would pass validation and be left as-is. Now all titles are normalized to the canonical `vX.Y.Z: description` format.

## Fixed

- **Normalize release titles to `vX.Y.Z: description` format** — The previous check only prepended the tag when the title didn't start with it at all. If the LLM returned a title with a non-standard separator (e.g. parentheses or dashes), it passed the check unchanged. The normalization now strips any existing tag prefix with a non-standard separator and rewrites it consistently. The system prompt and tool description were also updated to guide the LLM toward the correct format from the start. ([#55](https://github.com/jdx/communique/pull/55)) (@jdx)

  | LLM output | Result |
  |---|---|
  | `v2.18.0 (Internal CI improvements)` | `v2.18.0: Internal CI improvements` |
  | `v2.18.0 - Internal CI improvements` | `v2.18.0: Internal CI improvements` |
  | `v2.18.0: Internal CI improvements` | `v2.18.0: Internal CI improvements` (unchanged) |
  | `Internal CI improvements` | `v2.18.0: Internal CI improvements` |

**Full Changelog**: https://github.com/jdx/communique/compare/v0.1.8...010f229