### PR TITLE
fix: normalize release title to "vX.Y.Z: description" format

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -19,7 +19,7 @@ When you are done researching, call the `submit_release_notes` tool with three f
 A concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized bullet points. Reference relevant PRs, issues, and commits as markdown links — e.g. `[#123](https://github.com/OWNER/REPO/pull/123)` for PRs/issues or `[abc1234](https://github.com/OWNER/REPO/commit/abc1234)` for commits.
 
 ### `release_title`
-A catchy, concise title for the GitHub release (no # prefix).
+A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as "vX.Y.Z: your title").
 
 ### `release_body`
 Detailed GitHub release notes in markdown. Use the following template as a base, including or omitting sections as appropriate for the release:

--- a/src/tools/submit_release_notes.rs
+++ b/src/tools/submit_release_notes.rs
@@ -15,7 +15,7 @@ pub fn definition() -> ToolDefinition {
                 },
                 "release_title": {
                     "type": "string",
-                    "description": "A catchy, concise title for the GitHub release (no # prefix)."
+                    "description": "A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as 'vX.Y.Z: your title')."
                 },
                 "release_body": {
                     "type": "string",


### PR DESCRIPTION
## Summary

- The previous check only prepended the tag when the title didn't start with it at all
- If the LLM returned e.g. `v2.18.0 (Internal CI improvements)`, the check passed and the title kept its parentheses — seen in [jdx/usage v2.18.0](https://github.com/jdx/usage/releases/tag/v2.18.0)
- Now strips any existing tag prefix with a non-standard separator and rewrites as `vX.Y.Z: description`
- Also updates the system prompt and tool description to guide the LLM toward the correct format from the start

## Normalization behavior

| LLM output | Result |
|---|---|
| `v2.18.0 (Internal CI improvements)` | `v2.18.0: Internal CI improvements` |
| `v2.18.0 - Internal CI improvements` | `v2.18.0: Internal CI improvements` |
| `v2.18.0: Internal CI improvements` | `v2.18.0: Internal CI improvements` (unchanged) |
| `Internal CI improvements` | `v2.18.0: Internal CI improvements` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)