### PR TITLE
v1.0.0: Dependency Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.10](https://github.com/jdx/communique/releases/tag/v0.1.10) - 2026-04-19
+## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/jdx/communique/releases/tag/v0.1.10) - 2026-04-19
+
+### Changed
+
+- Updated `clx` dependency to v2 ([#98](https://github.com/jdx/communique/pull/98))
+- Updated `toml` dependency from 0.8 → 1.0 ([#65](https://github.com/jdx/communique/pull/65), [#90](https://github.com/jdx/communique/pull/90))
+- Refreshed lockfile to resolve `cargo audit` findings for patched transitive dependencies ([#100](https://github.com/jdx/communique/pull/100))
+
 ## [0.1.9](https://github.com/jdx/communique/compare/v0.1.8...v0.1.9) - 2026-03-02
 
 ### Fixed
@@ -33,9 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Propagated errors from the list releases API call in the `get_release_by_tag` fallback instead of silently swallowing them, fixing misleading "No GitHub release found" messages ([#49](https://github.com/jdx/communique/pull/49))
-
-## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
+- Propagated errors from the list releases API call in the `get_release_by_tag` fallback instead of silently swallowing them, fixing misleading "No GitHub release found" messages ([#49](https://github.com/jdx/communique/pull/49))## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
 
 ### Other
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "0.1.10"
+version = "1.0.0"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "0.1.10"
+version = "1.0.0"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.9"
+version "0.1.10"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "0.1.10"
+version "1.0.0"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.10",
+  "version": "1.0.0",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "0.1.9",
+  "version": "0.1.10",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.9
+**Version**: 0.1.10
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 0.1.10
+**Version**: 1.0.0
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A dependency-only maintenance release with no changes to communiqué's own code. Key Rust crate dependencies (`clx`, `toml`) were bumped to their latest major versions, and the lockfile was refreshed to pull in patched transitive dependencies and resolve `cargo audit` findings.

### Changed

- **Updated `clx` to v2** — Picks up the new `ProgressOutput::Quiet` variant and an updated `strum` dependency from the upstream clx library. ([#98](https://github.com/jdx/communique/pull/98))
- **Updated `toml` to v1** — Bumped from 0.8 through 0.9 to the stable 1.0 release. ([#65](https://github.com/jdx/communique/pull/65), [#90](https://github.com/jdx/communique/pull/90))
- **Refreshed lockfile for `cargo audit`** — Updated transitive dependencies including `aws-lc-rs`, `rustls-webpki`, `tokio`, and `rand` to their latest patched versions, clearing CI audit failures. ([#100](https://github.com/jdx/communique/pull/100)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major-version dependency upgrades (`clx` v2 and `toml` v1.0) and a refreshed lockfile that could change runtime behavior or introduce subtle regressions. Also updates the changelog, where a formatting/merge issue around older entries may need review.
> 
> **Overview**
> Prepares the `1.0.0` release by bumping the crate/CLI version from `0.1.9` → `1.0.0`, refreshing `Cargo.lock`, and updating generated CLI docs/specs to match.
> 
> Updates the changelog with a new `1.0.0` entry covering dependency maintenance (`clx` v2, `toml` 1.0, and transitive patch updates), but introduces a likely formatting issue where the `0.1.8` fixed entry runs into the `0.1.7` heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdbfaab8d0dfc53470c2bcf69842980b573e505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->