### PR TITLE
chore: default model to claude-opus-4-7

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -36,14 +36,14 @@ Default parameters for generation. All values can be overridden via CLI flags.
 
 ```toml
 [defaults]
-model = "claude-opus-4-6"
+model = "claude-opus-4-7"
 max_tokens = 4096
 repo = "owner/repo"
 ```
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `model` | Model identifier | `claude-opus-4-6` |
+| `model` | Model identifier | `claude-opus-4-7` |
 | `max_tokens` | Maximum response tokens | `4096` |
 | `repo` | GitHub repo in `owner/repo` format | Auto-detected from git remote |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ const TEMPLATE: &str = r#"# Extra instructions appended to the system prompt.
 #context = ""
 
 [defaults]
-#model = "claude-opus-4-6"
+#model = "claude-opus-4-7"
 #max_tokens = 4096
 #repo = "owner/repo"
 #provider = "anthropic"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -124,7 +124,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
         .model
         .clone()
         .or(defaults.model.clone())
-        .unwrap_or_else(|| "claude-opus-4-6".into());
+        .unwrap_or_else(|| "claude-opus-4-7".into());
     let max_tokens = opts.max_tokens.or(defaults.max_tokens).unwrap_or(4096);
     let owner_repo = match opts.repo.clone().or(defaults.repo.clone()) {
         Some(r) => r,


### PR DESCRIPTION
## Summary
- Bump the fallback default model from `claude-opus-4-6` to `claude-opus-4-7` in `generate.rs`
- Update the example config in `config.rs` and the configuration docs to match

## Test plan
- [x] `cargo build` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the default/fallback LLM model identifier and updates docs/templates to match, without altering generation flow or data handling.
> 
> **Overview**
> Updates the built-in fallback model used when no CLI/config `model` is provided from `claude-opus-4-6` to `claude-opus-4-7`.
> 
> Aligns the sample `communique.toml` template (`src/config.rs`) and configuration guide (`docs/guide/configuration.md`) to reflect the new default model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a335cd46d2b48c05574431adc707f2b997ffc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->