### PR TITLE
v1.0.1: Default to Claude Opus 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/jdx/communique/releases/tag/v1.0.1) - 2026-04-20
+
+## Changed
+
+- Bumped the default model from `claude-opus-4-6` to `claude-opus-4-7` ([#101](https://github.com/jdx/communique/pull/101))
+
 ## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
 
 ### Changed
@@ -31,9 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(deps)* update rust crate clap to v4.5.60 ([#59](https://github.com/jdx/communique/pull/59))
 - *(deps)* pin dependencies ([#58](https://github.com/jdx/communique/pull/58))
 - *(deps)* update rust crate futures-util to v0.3.32 ([#56](https://github.com/jdx/communique/pull/56))
-- run render and lint-fix when creating release PR ([#53](https://github.com/jdx/communique/pull/53))
-
-## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
+- run render and lint-fix when creating release PR ([#53](https://github.com/jdx/communique/pull/53))## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.0.0"
+version "1.0.1"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.0
+**Version**: 1.0.1
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that bumps the built-in default model to the latest Claude Opus version.

## Changed

- **Default model bumped to `claude-opus-4-7`** — The fallback model used when no `model` is set via CLI flag or config is now `claude-opus-4-7` (previously `claude-opus-4-6`). The sample `communique.toml` template and the configuration docs were updated to match. Users who pin a model in their config or pass `--model` are unaffected. ([#101](https://github.com/jdx/communique/pull/101)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a patch version bump and regenerated docs/changelog entries; no functional code paths are modified in the diff.
> 
> **Overview**
> Publishes the `1.0.1` patch release by bumping the crate/CLI version from `1.0.0` to `1.0.1` across `Cargo.toml`, `Cargo.lock`, the usage spec, and generated CLI docs.
> 
> Updates `CHANGELOG.md` with a new `1.0.1` entry noting the default model bump to `claude-opus-4-7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05097f1457924ea68b9b0781c2e21a335d11fb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->