### PR TITLE
v1.0.2: Resilient Release Note Submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21
+
+## Fixed
+
+- Retry malformed `submit_release_notes` tool calls instead of aborting the run, with a cap of 3 attempts ([#105](https://github.com/jdx/communique/pull/105))
+
 ## [1.0.1](https://github.com/jdx/communique/releases/tag/v1.0.1) - 2026-04-20
 
 ## Changed
 
-- Bumped the default model from `claude-opus-4-6` to `claude-opus-4-7` ([#101](https://github.com/jdx/communique/pull/101))
-
-## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
+- Bumped the default model from `claude-opus-4-6` to `claude-opus-4-7` ([#101](https://github.com/jdx/communique/pull/101))## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.0.1"
+version "1.0.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.1
+**Version**: 1.0.2
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that makes communiqué more resilient when the model emits a malformed final tool call.

## Fixed

- **Retry malformed release note submissions** — When the model calls `submit_release_notes` without all three required string fields (`changelog`, `release_title`, `release_body`), the agent now returns a tool error explaining which field is missing and asks the model to try again, rather than aborting the entire run. Retries are capped at 3 malformed submissions to avoid spinning, after which the command fails with a clear parse error. This previously caused `communique generate --github-release` to fail after all the research work had already been done. ([#105](https://github.com/jdx/communique/pull/105)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk control-flow change that only affects error handling when the LLM emits an invalid `submit_release_notes` tool call; normal successful paths are unchanged.
> 
> **Overview**
> Improves resilience of `communique generate --github-release` by treating malformed `submit_release_notes` tool calls as recoverable: the agent now returns a tool error explaining the missing field(s), continues the loop, and retries up to `MAX_MALFORMED_SUBMISSIONS` (3) before failing with a clear parse error.
> 
> Bumps the project version to `1.0.2` and updates generated CLI docs/usage spec and `CHANGELOG.md` with the `1.0.2` release entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8eb499a3883ae9413e7c7b9a13fb099d4d066d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->