### PR TITLE
fix: retry malformed release note submissions

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,6 +13,28 @@ use crate::tools;
 
 const MAX_ITERATIONS: usize = 25;
 
+fn parse_submission(input: &serde_json::Value, usage: &Usage) -> Result<ParsedOutput> {
+    let changelog = input["changelog"]
+        .as_str()
+        .ok_or_else(|| Error::Parse("missing changelog in submission".into()))?
+        .to_string();
+    let release_title = input["release_title"]
+        .as_str()
+        .ok_or_else(|| Error::Parse("missing release_title in submission".into()))?
+        .to_string();
+    let release_body = input["release_body"]
+        .as_str()
+        .ok_or_else(|| Error::Parse("missing release_body in submission".into()))?
+        .to_string();
+
+    Ok(ParsedOutput {
+        changelog,
+        release_title,
+        release_body,
+        usage: usage.clone(),
+    })
+}
+
 pub struct AgentContext<'a> {
     pub client: &'a dyn LlmClient,
     pub system: &'a str,
@@ -59,29 +81,20 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
 
         // Check for submit_release_notes tool call — this is the final output
         let mut submit = None;
+        let mut malformed_submit = Vec::new();
         for tc in &response.tool_calls {
             if tc.name == "submit_release_notes" {
-                let changelog = tc.input["changelog"]
-                    .as_str()
-                    .ok_or_else(|| Error::Parse("missing changelog in submission".into()))?
-                    .to_string();
-                let release_title = tc.input["release_title"]
-                    .as_str()
-                    .ok_or_else(|| Error::Parse("missing release_title in submission".into()))?
-                    .to_string();
-                let release_body = tc.input["release_body"]
-                    .as_str()
-                    .ok_or_else(|| Error::Parse("missing release_body in submission".into()))?
-                    .to_string();
-                submit = Some((
-                    tc.id.clone(),
-                    ParsedOutput {
-                        changelog,
-                        release_title,
-                        release_body,
-                        usage: total_usage.clone(),
-                    },
-                ));
+                match parse_submission(&tc.input, &total_usage) {
+                    Ok(parsed) => submit = Some((tc.id.clone(), parsed)),
+                    Err(Error::Parse(message)) => malformed_submit.push(ToolResult {
+                        tool_call_id: tc.id.clone(),
+                        content: format!(
+                            "Error: {message}\n\nPlease call submit_release_notes again with string values for changelog, release_title, and release_body."
+                        ),
+                        is_error: true,
+                    }),
+                    Err(err) => return Err(err),
+                }
             }
         }
 
@@ -111,6 +124,11 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
                 }
             }
             return Ok(parsed);
+        }
+
+        if !malformed_submit.is_empty() {
+            client.append_tool_results(&mut conversation, &malformed_submit);
+            continue;
         }
 
         if response.tool_calls.is_empty() || response.stop_reason == StopReason::EndTurn {
@@ -401,20 +419,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_missing_changelog_field() {
-        let client = MockLlmClient::new(vec![TurnResponse {
-            tool_calls: vec![ToolCall {
-                id: "call_1".into(),
-                name: "submit_release_notes".into(),
-                input: json!({
-                    "release_title": "v1.0",
-                    "release_body": "body",
-                }),
-            }],
-            text: None,
-            stop_reason: StopReason::ToolUse,
-            usage: fake_usage(),
-        }]);
+    async fn test_missing_changelog_field_retries_submission() {
+        let client = MockLlmClient::new(vec![
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "release_title": "v1.0",
+                        "release_body": "body",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+            TurnResponse {
+                tool_calls: vec![submit_tool_call("log", "v1.0", "body")],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+        ]);
         let job = Arc::new(ProgressJobBuilder::new().build());
         let tmp = std::env::temp_dir();
         let ctx = AgentContext {
@@ -427,26 +453,35 @@ mod tests {
             verify_links: false,
             job: &job,
         };
-        let err = run(ctx).await.unwrap_err();
-        assert!(matches!(err, Error::Parse(_)));
-        assert!(err.to_string().contains("changelog"));
+        let result = run(ctx).await.unwrap();
+        assert_eq!(result.changelog, "log");
+        assert_eq!(result.release_title, "v1.0");
+        assert_eq!(result.release_body, "body");
     }
 
     #[tokio::test]
-    async fn test_missing_release_title_field() {
-        let client = MockLlmClient::new(vec![TurnResponse {
-            tool_calls: vec![ToolCall {
-                id: "call_1".into(),
-                name: "submit_release_notes".into(),
-                input: json!({
-                    "changelog": "log",
-                    "release_body": "body",
-                }),
-            }],
-            text: None,
-            stop_reason: StopReason::ToolUse,
-            usage: fake_usage(),
-        }]);
+    async fn test_missing_release_title_field_retries_submission() {
+        let client = MockLlmClient::new(vec![
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "changelog": "log",
+                        "release_body": "body",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+            TurnResponse {
+                tool_calls: vec![submit_tool_call("log", "v1.0", "body")],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+        ]);
         let job = Arc::new(ProgressJobBuilder::new().build());
         let tmp = std::env::temp_dir();
         let ctx = AgentContext {
@@ -459,26 +494,35 @@ mod tests {
             verify_links: false,
             job: &job,
         };
-        let err = run(ctx).await.unwrap_err();
-        assert!(matches!(err, Error::Parse(_)));
-        assert!(err.to_string().contains("release_title"));
+        let result = run(ctx).await.unwrap();
+        assert_eq!(result.changelog, "log");
+        assert_eq!(result.release_title, "v1.0");
+        assert_eq!(result.release_body, "body");
     }
 
     #[tokio::test]
-    async fn test_missing_release_body_field() {
-        let client = MockLlmClient::new(vec![TurnResponse {
-            tool_calls: vec![ToolCall {
-                id: "call_1".into(),
-                name: "submit_release_notes".into(),
-                input: json!({
-                    "changelog": "log",
-                    "release_title": "v1.0",
-                }),
-            }],
-            text: None,
-            stop_reason: StopReason::ToolUse,
-            usage: fake_usage(),
-        }]);
+    async fn test_missing_release_body_field_retries_submission() {
+        let client = MockLlmClient::new(vec![
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "changelog": "log",
+                        "release_title": "v1.0",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+            TurnResponse {
+                tool_calls: vec![submit_tool_call("log", "v1.0", "body")],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+        ]);
         let job = Arc::new(ProgressJobBuilder::new().build());
         let tmp = std::env::temp_dir();
         let ctx = AgentContext {
@@ -491,9 +535,10 @@ mod tests {
             verify_links: false,
             job: &job,
         };
-        let err = run(ctx).await.unwrap_err();
-        assert!(matches!(err, Error::Parse(_)));
-        assert!(err.to_string().contains("release_body"));
+        let result = run(ctx).await.unwrap();
+        assert_eq!(result.changelog, "log");
+        assert_eq!(result.release_title, "v1.0");
+        assert_eq!(result.release_body, "body");
     }
 
     #[tokio::test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,6 +12,7 @@ use crate::output::{self, ParsedOutput};
 use crate::tools;
 
 const MAX_ITERATIONS: usize = 25;
+const MAX_MALFORMED_SUBMISSIONS: usize = 3;
 
 fn parse_submission(input: &serde_json::Value, usage: &Usage) -> Result<ParsedOutput> {
     let changelog = input["changelog"]
@@ -61,6 +62,7 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
     let mut conversation = client.new_conversation(user_message);
     let mut cache = tools::ToolCache::new();
     let mut total_usage = Usage::default();
+    let mut malformed_submission_count = 0;
 
     for iteration in 0..MAX_ITERATIONS {
         info!("agent iteration {}", iteration + 1);
@@ -127,6 +129,12 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         }
 
         if !malformed_submit.is_empty() {
+            malformed_submission_count += malformed_submit.len();
+            if malformed_submission_count >= MAX_MALFORMED_SUBMISSIONS {
+                return Err(Error::Parse(format!(
+                    "submit_release_notes was malformed {malformed_submission_count} times"
+                )));
+            }
             client.append_tool_results(&mut conversation, &malformed_submit);
             continue;
         }
@@ -539,6 +547,66 @@ mod tests {
         assert_eq!(result.changelog, "log");
         assert_eq!(result.release_title, "v1.0");
         assert_eq!(result.release_body, "body");
+    }
+
+    #[tokio::test]
+    async fn test_malformed_submission_retry_limit() {
+        let client = MockLlmClient::new(vec![
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_1".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "changelog": "log",
+                        "release_title": "v1.0",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_2".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "changelog": "log",
+                        "release_title": "v1.0",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+            TurnResponse {
+                tool_calls: vec![ToolCall {
+                    id: "call_3".into(),
+                    name: "submit_release_notes".into(),
+                    input: json!({
+                        "changelog": "log",
+                        "release_title": "v1.0",
+                    }),
+                }],
+                text: None,
+                stop_reason: StopReason::ToolUse,
+                usage: fake_usage(),
+            },
+        ]);
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        let tmp = std::env::temp_dir();
+        let ctx = AgentContext {
+            client: &client,
+            system: "",
+            user_message: "",
+            tool_defs: vec![],
+            repo_root: &tmp,
+            github: None,
+            verify_links: false,
+            job: &job,
+        };
+        let err = run(ctx).await.unwrap_err();
+        assert!(matches!(err, Error::Parse(_)));
+        assert!(err.to_string().contains("malformed 3 times"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- treat malformed `submit_release_notes` tool calls as retryable tool errors instead of aborting the run immediately
- cap malformed final-submission retries at 3 attempts so the agent fails fast if the model keeps emitting broken payloads
- keep the existing success path unchanged when all three required fields are present
- update the agent tests to cover retry behavior for missing `changelog`, `release_title`, and `release_body`, plus the retry-limit failure case

## Why
`communique generate "$TAG" --github-release` failed while enhancing the `aube` v1.0.0-beta.10 release notes with:

```text
parse error: missing release_body in submission
```

That happened after the model had already done the research/tool-use work. The failure mode here is not that the overall generation was impossible; it is that the final `submit_release_notes` tool call was malformed. Aborting immediately on the first malformed submission makes release-note generation brittle.

This change treats that case like other retryable tool feedback: the agent returns a tool error telling the model which required field is missing and asks it to call `submit_release_notes` again with all string fields present. To avoid spinning, that retry path is capped at 3 malformed final submissions before the command fails with a specific parse error.

## Validation
- `cargo test`
