### PR TITLE
chore(release): append en.dev sponsor blurb to release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -100,6 +100,23 @@ jobs:
         run: |
           cargo build
           ./target/debug/communique generate "${{ needs.release-plz-release.outputs.tag }}" --github-release
+      - name: Append en.dev sponsor blurb
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: |
+          {
+            gh release view "$TAG" --json body --jq .body
+            cat <<'EOF'
+
+          ## 💚 Sponsor communique
+
+          communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.
+
+          If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.
+          EOF
+          } > /tmp/release-notes.md
+          gh release edit "$TAG" --notes-file /tmp/release-notes.md
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary

- Appends a **Sponsor communique** section to every GitHub Release body, run after `communique generate` in the `enhance-release` job in [`.github/workflows/release-plz.yml`](.github/workflows/release-plz.yml).
- Same pattern as [mise#9272](https://github.com/jdx/mise/pull/9272), adapted for communique.

## What it looks like

Rendered at the bottom of each release body:

> ## 💚 Sponsor communique
>
> communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.
>
> If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.

## Test plan

- [x] \`actionlint\` + \`yamllint\` pass on the modified workflow
- [ ] Next tagged release produces a GitHub Release whose body ends with the sponsor section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI/workflow-only change that edits GitHub Release text after generation; main risk is accidental overwriting/formatting of release notes if the `gh` step fails or output changes.
> 
> **Overview**
> After `communique generate` runs in the `enhance-release` workflow, the job now **appends a “Sponsor communique” section** to the existing GitHub Release body.
> 
> This is implemented by fetching the current release notes via `gh release view`, concatenating the sponsor blurb, and updating the release via `gh release edit --notes-file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 432e7ebde31eeb9db18f6b5b15dc70635971cc0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->