### PR TITLE
fix(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,9 +2035,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bump `rustls-webpki` 0.103.12 → 0.103.13 in `Cargo.lock` to address [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (reachable panic in certificate revocation list parsing), flagged by `cargo audit` in CI.

## Test plan
- [x] `cargo build` succeeds
- [ ] `cargo audit` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code-change risk since this is a lockfile-only dependency bump, but it affects TLS certificate validation behavior and should be verified in CI to avoid unexpected runtime differences.
> 
> **Overview**
> Updates `Cargo.lock` to bump `rustls-webpki` from `0.103.12` to `0.103.13` (checksum updated) to pick up the security fix referenced by `RUSTSEC-2026-0104`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28c6a883254ea657f5911ce3e3cae246583f45a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->