### PR TITLE
v1.0.3: UTF-8 boundary fix + rustls-webpki security bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
+
+### Fixed
+
+- *(prompt)* truncate recent release bodies on UTF-8 char boundary ([#113](https://github.com/jdx/communique/pull/113))
+
+### Other
+
+- keep banner height in sync via ResizeObserver ([#112](https://github.com/jdx/communique/pull/112))
+- banner cache + fallback color tweaks ([#111](https://github.com/jdx/communique/pull/111))
+- polish banner + add en.dev footer ([#110](https://github.com/jdx/communique/pull/110))
+- add cross-site announcement banner ([#109](https://github.com/jdx/communique/pull/109))
+- *(release)* append en.dev sponsor blurb to release notes ([#106](https://github.com/jdx/communique/pull/106))
+
 ## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.0.2"
+version "1.0.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.2
+**Version**: 1.0.3
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that fixes a panic when generating notes against releases with multi-byte characters in their bodies, and picks up a security fix in `rustls-webpki`.

## Fixed

- **Don't panic on multi-byte chars in style-reference bodies** — `communique generate` truncates each recent release body to 3072 bytes to keep the prompt small, but previously sliced `&body[..3072]` directly. If byte 3072 fell inside a multi-byte UTF-8 character (common with em-dashes, which are 3 bytes), the command would panic with `byte index 3072 is not a char boundary`. The truncation now walks back to the nearest char boundary before slicing, with a regression test covering the case. ([#113](https://github.com/jdx/communique/pull/113)) (@jdx)

## Security

- **`rustls-webpki` bumped to 0.103.13** — Addresses [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104), a reachable panic in certificate revocation list parsing. Lockfile-only change. ([#107](https://github.com/jdx/communique/pull/107)) (@jdx)

## Docs

- Added a dismissible cross-site announcement banner and an en.dev footer to the documentation site, with follow-up polish (contrast, centering, z-index), smarter caching, and `ResizeObserver`-based height syncing so VitePress's nav offset stays correct on resize. ([#109](https://github.com/jdx/communique/pull/109), [#110](https://github.com/jdx/communique/pull/110), [#111](https://github.com/jdx/communique/pull/111), [#112](https://github.com/jdx/communique/pull/112)) (@jdx)