### PR TITLE
docs: polish banner + add en.dev footer

### DIFF
--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -1,0 +1,58 @@
+<template>
+  <footer class="EndevFooter">
+    <span>MIT License</span>
+    <span aria-hidden="true">·</span>
+    <span>Copyright © {{ year }}</span>
+    <span aria-hidden="true">·</span>
+    <a class="EndevFooterLink" href="https://en.dev">
+      <img
+        alt=""
+        class="EndevFooterLogo"
+        height="28"
+        src="https://github.com/endevco.png?size=96"
+        width="28"
+      />
+      <span>en.dev</span>
+    </a>
+  </footer>
+</template>
+
+<script setup>
+const year = new Date().getFullYear();
+</script>
+
+<style scoped>
+.EndevFooter {
+  align-items: center;
+  border-top: 1px solid var(--vp-c-divider);
+  color: var(--vp-c-text-2);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 14px;
+  gap: 8px;
+  justify-content: center;
+  line-height: 28px;
+  margin-top: auto;
+  padding: 22px 24px 26px;
+  text-align: center;
+}
+.EndevFooterLink {
+  align-items: center;
+  color: inherit;
+  display: inline-flex;
+  gap: 8px;
+  line-height: 28px;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+.EndevFooterLink:hover {
+  color: var(--vp-c-brand-1);
+}
+.EndevFooterLogo {
+  border-radius: 8px;
+  display: inline-block;
+  height: 28px;
+  vertical-align: middle;
+  width: 28px;
+}
+</style>

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -3,31 +3,36 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 60;
+  z-index: 1001;
   display: flex;
   gap: 0.75rem;
   align-items: center;
-  padding: 0.5rem 1rem;
+  justify-content: center;
+  padding: 0.5rem 2.75rem 0.5rem 1rem;
   background: var(--vp-c-brand-1, #3451b2);
-  color: #fff;
+  color: #000;
   font-size: 0.9rem;
   line-height: 1.4;
+  text-align: center;
 }
 .jdx-banner a {
-  color: #fff;
+  color: #000;
   text-decoration: underline;
-  font-weight: 500;
+  font-weight: 600;
 }
 .jdx-banner button {
-  margin-left: auto;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
   background: transparent;
   border: 0;
-  color: #fff;
+  color: inherit;
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;
-  padding: 0 0.25rem;
-  opacity: 0.85;
+  padding: 0 0.5rem;
+  opacity: 0.7;
 }
 .jdx-banner button:hover {
   opacity: 1;
@@ -35,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -8,7 +8,7 @@
   gap: 0.75rem;
   align-items: center;
   justify-content: center;
-  padding: 0.5rem 2.75rem 0.5rem 1rem;
+  padding: 0.5rem 2.75rem;
   background: var(--vp-c-brand-1, #3451b2);
   color: #000;
   font-size: 0.9rem;
@@ -40,6 +40,6 @@
 @media (max-width: 640px) {
   .jdx-banner {
     font-size: 0.85rem;
-    padding: 0.4rem 2.5rem 0.4rem 0.75rem;
+    padding: 0.4rem 2.5rem;
   }
 }

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -46,7 +46,7 @@ function render(b: BannerData): void {
     const a = document.createElement("a");
     a.href = b.link;
     a.target = "_blank";
-    a.rel = "noopener noreferrer";
+    a.rel = "noopener";
     a.textContent = b.linkText || "Learn more";
     el.appendChild(a);
   }

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,10 +1,17 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
+import { h } from "vue";
 import { initBanner } from "./banner";
+import EndevFooter from "./EndevFooter.vue";
 import "./custom.css";
 
 export default {
   extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "layout-bottom": () => h(EndevFooter),
+    });
+  },
   enhanceApp() {
     initBanner();
   },


### PR DESCRIPTION
Follow-ups to #109 that landed after the merge, plus the en.dev footer.

## Summary
### Banner polish
- **Contrast**: switch to dark text on the pink brand bg (white text failed contrast)
- **z-index**: bump to 1001 so the banner stays above the site's nav
- **Centering**: message + link centered; dismiss button pinned to the right via absolute positioning
- **Analytics**: drop `rel=noreferrer` so en.dev gets referrer attribution. Keep `rel=noopener`.

### Footer
- Adds the en.dev footer matching the one on the mise docs, via VitePress's `layout-bottom` slot

## Test plan
- [ ] Run docs dev server, confirm banner text is centered and readable
- [ ] Confirm en.dev footer appears at the bottom of pages
- [ ] Click the \u00d7 on the banner \u2014 dismisses and stays hidden across reload

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docs-only theme/CSS tweaks plus a small `rel` attribute change on an external link; no backend or data model impact.
> 
> **Overview**
> Polishes the docs site announcement banner styling to improve readability and layout (dark text, centered content, higher `z-index`, and an absolutely positioned dismiss button), with updated responsive padding.
> 
> Adds a new `EndevFooter` component and wires it into VitePress via the `layout-bottom` slot, and adjusts the banner link to use `rel="noopener"` (dropping `noreferrer`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151266ab3bafc9f4a251d28ea46820e8e2b8b4d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->