### PR TITLE
docs: banner cache + fallback color tweaks

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -9,7 +9,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.5rem 2.75rem;
-  background: var(--vp-c-brand-1, #3451b2);
+  background: var(--vp-c-brand-1, #ff71ce);
   color: #000;
   font-size: 0.9rem;
   line-height: 1.4;

--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -13,7 +13,7 @@ const STORAGE_KEY = "jdx-banner-dismissed";
 
 export function initBanner(): void {
   if (typeof window === "undefined") return;
-  fetch(ENDPOINT, { cache: "no-cache" })
+  fetch(ENDPOINT)
     .then((r) => (r.ok ? (r.json() as Promise<BannerData>) : null))
     .then((b) => {
       if (!b || !b.enabled) return;


### PR DESCRIPTION
Follow-ups after #110 merged.

## Summary
- Drop \`cache: \"no-cache\"\` from the banner fetch. The server already sends \`Cache-Control: public, max-age=300, must-revalidate\`, so default browser caching gives 5-min freshness without a conditional GET on every page load.
- Fix the banner background fallback color. Previously fell back to \`#3451b2\` (VitePress dark blue), which rendered black banner text unreadable if \`--vp-c-brand-1\` ever fails to resolve. Now falls back to \`#ff71ce\` (the actual communique brand).

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts docs-site banner styling and removes a `no-cache` fetch option, which may slightly change how quickly banner updates propagate but doesn’t affect core app logic.
> 
> **Overview**
> Updates the docs announcement banner to rely on default browser caching by removing `cache: "no-cache"` from the `fetch` in `initBanner()`.
> 
> Also changes the banner background fallback color in `banner.css` to `#ff71ce` to keep text readable if `--vp-c-brand-1` isn’t defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ff10a07dbbe1e60580f5d20083be74f92bcf4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->