### PR TITLE
docs: keep banner height in sync via ResizeObserver

### DIFF
--- a/docs/.vitepress/theme/banner.ts
+++ b/docs/.vitepress/theme/banner.ts
@@ -51,12 +51,25 @@ function render(b: BannerData): void {
     el.appendChild(a);
   }
 
+  const syncHeight = () => {
+    document.documentElement.style.setProperty(
+      "--vp-layout-top-height",
+      `${el.offsetHeight}px`,
+    );
+  };
+
+  const observer =
+    typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(syncHeight)
+      : null;
+
   const btn = document.createElement("button");
   btn.type = "button";
   btn.setAttribute("aria-label", "Dismiss");
   btn.textContent = "\u00d7";
   btn.addEventListener("click", () => {
     localStorage.setItem(STORAGE_KEY, b.id);
+    observer?.disconnect();
     el.remove();
     document.documentElement.style.removeProperty("--vp-layout-top-height");
   });
@@ -64,10 +77,6 @@ function render(b: BannerData): void {
 
   document.body.prepend(el);
 
-  requestAnimationFrame(() => {
-    document.documentElement.style.setProperty(
-      "--vp-layout-top-height",
-      `${el.offsetHeight}px`,
-    );
-  });
+  requestAnimationFrame(syncHeight);
+  observer?.observe(el);
 }


### PR DESCRIPTION
## Summary
Follow-up fix for the banner.

\`--vp-layout-top-height\` was set once in a single rAF and never updated. On window resize, orientation change, or text reflow the banner height could change, leaving VitePress's nav offset stale and causing overlap or a visible gap. Observe the banner element and resync the variable whenever its size changes; disconnect the observer on dismiss.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-theme tweak that only affects banner layout; potential issues are limited to browsers without `ResizeObserver` support or unexpected observer behavior.
> 
> **Overview**
> Keeps VitePress’s `--vp-layout-top-height` CSS var in sync with the announcement banner’s actual height by introducing a `syncHeight` helper and observing the banner with `ResizeObserver`.
> 
> On dismiss, the observer is disconnected and the layout height var is removed, replacing the previous one-time `requestAnimationFrame` height set with ongoing updates on resize/reflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6393ae0b2685d0b4d91e39f236699def9ada9c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->