### PR TITLE
fix(prompt): truncate recent release bodies on UTF-8 char boundary

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -134,7 +134,11 @@ pub fn user_prompt(ctx: &UserPromptContext) -> String {
         );
         for (tag_name, body) in *recent_releases {
             let truncated = if body.len() > 3072 {
-                format!("{}...\n[truncated]", &body[..3072])
+                let mut end = 3072;
+                while !body.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...\n[truncated]", &body[..end])
             } else {
                 body.clone()
             };
@@ -249,6 +253,27 @@ mod tests {
             existing_release: None,
             context: None,
             recent_releases: &[("v1.0.0".into(), long_body)],
+        });
+        assert!(prompt.contains("[truncated]"));
+    }
+
+    #[test]
+    fn test_user_prompt_recent_releases_truncation_on_char_boundary() {
+        // Ensure truncation does not panic when the 3072-byte cutoff lands
+        // inside a multi-byte UTF-8 character (e.g. the em-dash '—', 3 bytes).
+        let mut body = "a".repeat(3070);
+        body.push('—');
+        body.push_str(&"b".repeat(2000));
+        let prompt = user_prompt(&UserPromptContext {
+            tag: "v2.0.0",
+            prev_tag: "v1.0.0",
+            owner_repo: "test/repo",
+            git_log: "abc init",
+            pr_numbers: &[],
+            changelog_entry: None,
+            existing_release: None,
+            context: None,
+            recent_releases: &[("v1.0.0".into(), body)],
         });
         assert!(prompt.contains("[truncated]"));
     }


### PR DESCRIPTION
## Summary

`src/prompt.rs`'s style-reference truncation sliced `&body[..3072]` directly, which panics whenever byte 3072 falls inside a multi-byte UTF-8 character. aube's release-notes style uses the em-dash `—` (3 bytes) heavily, so `communique generate` against [endevco/aube@v1.0.0](https://github.com/endevco/aube/releases/tag/v1.0.0) blew up with:

```
thread 'main' panicked at src/prompt.rs:137:52:
byte index 3072 is not a char boundary; it is inside '—' (bytes 3070..3073) of `aube v1.0.0-beta.12 is a reliability and reach release…`
```

(See the failed [enhance-release job](https://github.com/endevco/aube/actions/runs/24854719507/job/72767529235).)

Fix: walk back from 3072 to the nearest char boundary before slicing.

## Test plan

- [x] New regression test `test_user_prompt_recent_releases_truncation_on_char_boundary` reproduces the aube panic (em-dash straddling the 3072 cutoff) and now passes
- [x] `cargo test prompt::` — 8/8 pass
- [x] `cargo clippy` / `cargo fmt --check` clean (pre-commit hooks passed on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to prompt-string truncation logic and adds a regression test; main risk is only in edge-case formatting of truncated output.
> 
> **Overview**
> Fixes a panic in `user_prompt` when truncating "recent release" bodies by ensuring the 3072-byte cutoff is adjusted backward to a valid UTF-8 character boundary before slicing.
> 
> Adds a regression test covering the multi-byte character boundary case to prevent future crashes during style-reference generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c48ae1c5ea64f2082e8fe9d76eadfb15bb490f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->