### PR TITLE
v1.0.4: Mobile banner fix & resilient release-note submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
+
+## Fixed
+
+- **agent**: salvage partial `submit_release_notes` calls and surface better diagnostics instead of hard-failing after 3 malformed attempts ([#120](https://github.com/jdx/communique/pull/120))
+- **docs**: stack the announcement banner and pin the close button to the top-right on mobile viewports ([#119](https://github.com/jdx/communique/pull/119))
+
 ## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
 
 ### Fixed
@@ -21,9 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add cross-site announcement banner ([#109](https://github.com/jdx/communique/pull/109))
 - *(release)* append en.dev sponsor blurb to release notes ([#106](https://github.com/jdx/communique/pull/106))
 
-## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21
-
-## Fixed
+## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21## Fixed
 
 - Retry malformed `submit_release_notes` tool calls instead of aborting the run, with a cap of 3 attempts ([#105](https://github.com/jdx/communique/pull/105))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.0.3"
+version "1.0.4"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.3
+**Version**: 1.0.4
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that keeps `communique generate --github-release` from throwing away a whole CI run over a malformed final tool call, and tidies up the docs-site announcement banner on mobile.

## Fixed

- **Salvage partial `submit_release_notes` submissions** — When the model calls `submit_release_notes` with malformed arguments 3 times in a row (e.g. `changelog` as an array instead of a string, or `release_body` truncated by `max_tokens`), the agent no longer aborts the run. At the retry limit it now attempts a lenient parse of the most recent submission: non-string fields are coerced (arrays join with newlines, objects are JSON-stringified), missing fields are derived from what's present (`changelog` ⇄ `release_body`, `release_title` from the body's first line), and only when every content field is empty does the run fail. Real-world CI runs like [endevco/aube#24903381187](https://github.com/endevco/aube/actions/runs/24903381187) used to burn their entire research budget on this; they now recover automatically. ([#120](https://github.com/jdx/communique/pull/120)) (@jdx)
- **Better error diagnostics on unsalvageable submissions** — A new `Error::MalformedSubmission` variant uses miette's `Diagnostic` to embed the received JSON via `#[source_code]` and aggregate per-field reasons across all attempts, so the CLI prints something like `missing 'release_body'; 'changelog' must be a string (got array)` alongside the offending payload instead of the old opaque `malformed 3 times`. ([#120](https://github.com/jdx/communique/pull/120)) (@jdx)
- **Docs announcement banner on mobile** — On viewports ≤640px the banner was rendering cramped: `flex-wrap: nowrap` forced the message onto two squeezed lines and the "Read more" link sat jammed against the text. The banner now switches to `flex-direction: column` so the message and link stack cleanly, with a slightly smaller font, tighter line-height, `text-wrap: balance` for even line breaks, and the × close button pinned flush to the top-right corner. Matches the same fix rolling out across the mise, hk, aube, pitchfork, usage, and fnox docs sites. ([#119](https://github.com/jdx/communique/pull/119)) (@jdx)

## 💚 Sponsor communique

communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-metadata update (version bumps and changelog/CLI docs regen) with no functional code changes; main risk is minor documentation/changelog formatting errors.
> 
> **Overview**
> Prepares the `v1.0.4` patch release by bumping the crate/CLI version across `Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and the generated docs (`docs/cli/*`).
> 
> Updates `CHANGELOG.md` with a new `1.0.4` *Fixed* entry, but also changes formatting around the `1.0.2`/`1.0.0` sections (some headings are now concatenated onto the same line).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8b6ea7e9bf7a43c879713fc514c897f0a56ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->