### PR TITLE
fix(docs): stack banner and pin close button on mobile

### DIFF
--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -47,6 +47,8 @@
     text-wrap: balance;
   }
   .jdx-banner button {
+    top: 0.25rem;
     right: 0.25rem;
+    transform: none;
   }
 }

--- a/docs/.vitepress/theme/banner.css
+++ b/docs/.vitepress/theme/banner.css
@@ -39,7 +39,14 @@
 }
 @media (max-width: 640px) {
   .jdx-banner {
-    font-size: 0.85rem;
-    padding: 0.4rem 2.5rem;
+    flex-direction: column;
+    gap: 0.125rem;
+    font-size: 0.8rem;
+    padding: 0.5rem 2.25rem;
+    line-height: 1.3;
+    text-wrap: balance;
+  }
+  .jdx-banner button {
+    right: 0.25rem;
   }
 }


### PR DESCRIPTION
## Summary
- On narrow viewports the site banner rendered cramped: `flex-wrap: nowrap` forced the message onto two squeezed lines while the "Read more" link sat jammed against the text.
- At `<=640px`, switch the banner to `flex-direction: column` so the message and link stack cleanly. Shrink font slightly, tighten line-height, add `text-wrap: balance` for even two-line breaks, and pin the close button flush to the top-right corner.

Matches the same fix going out across the mise, hk, aube, pitchfork, usage, fnox, and communique docs.

## Test plan
- [ ] Visit the docs site on a mobile device (or DevTools <=640px) after deploy and confirm the banner stacks cleanly with the × button in the top-right corner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change limited to the docs banner layout on small viewports.
> 
> **Overview**
> Improves the docs site announcement banner layout on screens `<=640px` by switching it to a stacked (`flex-direction: column`) layout with tighter spacing/typography and balanced wrapping.
> 
> Repositions the banner close button on mobile by pinning it to the top-right and removing the vertical centering transform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa47dbb9881b1a8102bc3150ee899c6102e5292e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->