### PR TITLE
feat(generate): support `HEAD --changelog` as `[Unreleased]` target

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -39,6 +39,67 @@ struct Context {
     github_client: Option<github::GitHubClient>,
 }
 
+impl Context {
+    fn is_unreleased_head(&self) -> bool {
+        self.tag == "HEAD"
+    }
+
+    fn display_tag(&self) -> &str {
+        if self.is_unreleased_head() {
+            "Unreleased"
+        } else {
+            &self.tag
+        }
+    }
+}
+
+fn validate_generate_options(opts: &GenerateOptions) -> miette::Result<()> {
+    if opts.github_release && opts.tag == "HEAD" {
+        return Err(miette::miette!(
+            "--github-release cannot be used with HEAD because HEAD is an unreleased changelog target. Use --changelog, or generate notes for a real tag."
+        ));
+    }
+
+    Ok(())
+}
+
+fn release_title_description<'a>(title: &'a str, label: &str) -> Option<&'a str> {
+    let rest = title.strip_prefix(label)?;
+    if rest.chars().next().is_some_and(char::is_alphanumeric) {
+        return None;
+    }
+
+    let trimmed = rest.trim_start_matches(|c: char| !c.is_alphanumeric());
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn normalize_release_title(title: String, display_tag: &str, raw_tag: &str) -> String {
+    let tag_prefix = format!("{display_tag}: ");
+    if title.starts_with(&tag_prefix) {
+        return title;
+    }
+
+    if raw_tag != display_tag && title.trim() == raw_tag {
+        return format!("{display_tag}: changes");
+    }
+
+    let description = release_title_description(&title, display_tag)
+        .or_else(|| {
+            if raw_tag == display_tag {
+                None
+            } else {
+                release_title_description(&title, raw_tag)
+            }
+        })
+        .unwrap_or(title.as_str());
+
+    format!("{display_tag}: {description}")
+}
+
 pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
     let job = ProgressJobBuilder::new()
         .body("{{spinner()}} {{message | flex}}")
@@ -48,25 +109,11 @@ pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
     let ctx = gather_context(&opts, &job).await?;
     let mut parsed = generate_notes(&ctx, opts.dry_run, &job).await?;
 
-    // Normalize release title to "vX.Y.Z: description" format.
+    // Normalize release title to "label: description" format.
     // The LLM may include the tag with a different separator (e.g. "v1.0.0 (title)"
-    // or "v1.0.0 - title"), so we check for the exact "tag: " prefix.
-    let tag_prefix = format!("{}: ", ctx.tag);
-    if !parsed.release_title.starts_with(&tag_prefix) {
-        let description = parsed
-            .release_title
-            .strip_prefix(&ctx.tag)
-            .and_then(|rest| {
-                let trimmed = rest.trim_start_matches(|c: char| !c.is_alphanumeric());
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(trimmed)
-                }
-            })
-            .unwrap_or(parsed.release_title.as_str());
-        parsed.release_title = format!("{}: {}", ctx.tag, description);
-    }
+    // or "v1.0.0 - title"), so we check for the exact "label: " prefix.
+    let display_tag = ctx.display_tag();
+    parsed.release_title = normalize_release_title(parsed.release_title, display_tag, &ctx.tag);
 
     publish(&opts, &ctx, &parsed, &job).await?;
 
@@ -102,6 +149,8 @@ pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
 }
 
 async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miette::Result<Context> {
+    validate_generate_options(opts)?;
+
     let github_token = std::env::var("GITHUB_TOKEN").ok();
 
     if opts.github_release && github_token.is_none() {
@@ -200,12 +249,22 @@ async fn generate_notes(
     );
 
     job.prop("message", "Fetching existing release context...");
-    let changelog_entry = read_changelog_entry(&ctx.repo_root, &ctx.tag);
+    let changelog_entry = if ctx.is_unreleased_head() {
+        read_unreleased_section(&ctx.repo_root)?
+    } else {
+        read_changelog_entry(&ctx.repo_root, &ctx.tag)
+    };
 
     // Fetch existing release and recent releases in parallel
     let match_style = ctx.defaults.match_style.unwrap_or(true);
     let (existing_release, recent_releases) = if let Some(gh) = &ctx.github_client {
-        let existing_fut = gh.get_release_by_tag(&ctx.tag);
+        let existing_fut = async {
+            if ctx.is_unreleased_head() {
+                Ok(None)
+            } else {
+                gh.get_release_by_tag(&ctx.tag).await
+            }
+        };
         let recent_fut = async {
             if !match_style {
                 return vec![];
@@ -248,6 +307,7 @@ async fn generate_notes(
         owner_repo: &ctx.owner_repo,
         git_log: &git_log,
         pr_numbers: &pr_numbers,
+        is_unreleased_head: ctx.is_unreleased_head(),
         changelog_entry: changelog_entry.as_deref(),
         existing_release: existing_release.as_deref(),
         context: ctx.context.as_deref(),
@@ -335,6 +395,71 @@ mod tests {
             output: None,
             config: None,
         }
+    }
+
+    fn test_context(repo_root: PathBuf, tag: &str, prev_tag: &str) -> Context {
+        Context {
+            repo_root,
+            owner_repo: "test/repo".into(),
+            tag: tag.into(),
+            prev_tag: prev_tag.into(),
+            client: Box::new(MockLlmClient::new(vec![])),
+            defaults: Defaults::default(),
+            system_extra: None,
+            context: None,
+            github_client: None,
+        }
+    }
+
+    fn test_parsed_output(changelog: &str) -> ParsedOutput {
+        ParsedOutput {
+            changelog: changelog.into(),
+            release_title: "Title".into(),
+            release_body: "Body".into(),
+            usage: Usage::default(),
+        }
+    }
+
+    #[test]
+    fn test_validate_generate_options_rejects_head_github_release() {
+        let opts = GenerateOptions {
+            github_release: true,
+            ..test_opts("HEAD")
+        };
+
+        let err = validate_generate_options(&opts).unwrap_err().to_string();
+        assert!(err.contains(
+            "--github-release cannot be used with HEAD because HEAD is an unreleased changelog target. Use --changelog, or generate notes for a real tag."
+        ));
+    }
+
+    #[test]
+    fn test_validate_generate_options_allows_head_changelog() {
+        let opts = GenerateOptions {
+            changelog: true,
+            ..test_opts("HEAD")
+        };
+
+        validate_generate_options(&opts).unwrap();
+    }
+
+    #[test]
+    fn test_normalize_release_title_uses_unreleased_display_tag_for_head() {
+        let title = normalize_release_title("HEAD - Draft changes".into(), "Unreleased", "HEAD");
+        assert_eq!(title, "Unreleased: Draft changes");
+        assert!(!title.starts_with("HEAD:"));
+    }
+
+    #[test]
+    fn test_normalize_release_title_preserves_tagged_behavior() {
+        let title = normalize_release_title("v1.2.3 - Feature release".into(), "v1.2.3", "v1.2.3");
+        assert_eq!(title, "v1.2.3: Feature release");
+    }
+
+    #[test]
+    fn test_normalize_release_title_does_not_strip_head_inside_word() {
+        let title = normalize_release_title("HEADline feature".into(), "Unreleased", "HEAD");
+        assert_eq!(title, "Unreleased: HEADline feature");
     }
 
     #[tokio::test]
@@ -608,6 +733,46 @@ mod tests {
         .unwrap();
         let entry = read_changelog_entry(dir.path(), "v1.0.0").unwrap();
         assert!(entry.contains("### Changed"));
+    }
+
+    #[test]
+    fn test_read_unreleased_section_bracketed() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## [Unreleased]\n\n### Changed\n- Draft\n\n## [1.0.0]\n- Old\n",
+        )
+        .unwrap();
+
+        let entry = read_unreleased_section(dir.path()).unwrap().unwrap();
+        assert_eq!(entry, "### Changed\n- Draft");
+        assert!(!entry.contains("1.0.0"));
+    }
+
+    #[test]
+    fn test_read_unreleased_section_plain() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## Unreleased\n\n### Fixed\n- Draft bug\n\n## 1.0.0\n- Old\n",
+        )
+        .unwrap();
+
+        let entry = read_unreleased_section(dir.path()).unwrap().unwrap();
+        assert_eq!(entry, "### Fixed\n- Draft bug");
+    }
+
+    #[test]
+    fn test_read_unreleased_section_missing_file_or_section() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_unreleased_section(dir.path()).unwrap().is_none());
+
+        std::fs::write(
+            dir.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## [1.0.0]\n- Old\n",
+        )
+        .unwrap();
+        assert!(read_unreleased_section(dir.path()).unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1060,6 +1225,126 @@ mod tests {
         assert!(tail.contains("[0.9.0]"));
     }
 
+    #[test]
+    fn test_replace_unreleased_section_bracketed_preserves_tail() {
+        let existing = "# Changelog\n\n## [Unreleased]\n\n### Changed\n- Old draft\n\n## [1.0.0] - 2025-01-01\n### Added\n- Old release\n";
+        let updated = replace_unreleased_section(existing, "### Added\n- New draft").unwrap();
+
+        assert_eq!(
+            updated,
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n- New draft\n\n## [1.0.0] - 2025-01-01\n### Added\n- Old release\n"
+        );
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_plain_preserves_header() {
+        let existing = "# Changelog\n\n## Unreleased\n\n- Old draft\n";
+        let updated = replace_unreleased_section(existing, "### Fixed\n- New fix").unwrap();
+
+        assert_eq!(
+            updated,
+            "# Changelog\n\n## Unreleased\n\n### Fixed\n- New fix\n"
+        );
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_errors_without_unreleased_header() {
+        let err = replace_unreleased_section("# Changelog\n\n## [1.0.0]\n- Old\n", "- New")
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("does not contain ## [Unreleased] or ## Unreleased"));
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_errors_on_duplicate_unreleased_headers() {
+        let err = replace_unreleased_section(
+            "# Changelog\n\n## [Unreleased]\n\n## Unreleased\n",
+            "- New",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("multiple Unreleased sections"));
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_removes_forbidden_target_headers() {
+        let existing = "# Changelog\n\n## [Unreleased]\n\n- Old\n";
+        let updated = replace_unreleased_section(existing, "## [HEAD]\n### Added\n- New").unwrap();
+
+        assert!(!updated.contains("## [HEAD]"));
+        assert!(!updated.contains("## HEAD"));
+        assert!(updated.contains("### Added\n- New"));
+    }
+
+    #[tokio::test]
+    async fn test_update_changelog_head_updates_unreleased_in_place() {
+        let repo = TempRepo::new();
+        let original = "# Changelog\n\nIntro text.\n\n## [Unreleased]\n\n### Changed\n- Old draft\n\n## [0.1.0] - 2026-01-01\n### Added\n- Initial release\n";
+        repo.write_file("CHANGELOG.md", original);
+
+        let ctx = test_context(repo.path().to_path_buf(), "HEAD", "v0.1.0");
+        let parsed = test_parsed_output("### Added\n- New draft");
+        let job = Arc::new(ProgressJobBuilder::new().build());
+
+        update_changelog(&ctx, &parsed, false, &job).await.unwrap();
+
+        let result = std::fs::read_to_string(repo.path().join("CHANGELOG.md")).unwrap();
+        assert!(result.contains("Intro text."));
+        assert!(result.contains("## [Unreleased]\n\n### Added\n- New draft"));
+        assert!(result.contains("## [0.1.0] - 2026-01-01\n### Added\n- Initial release"));
+        assert!(!result.contains("## [HEAD]"));
+        assert!(!result.contains("## HEAD"));
+    }
+
+    #[tokio::test]
+    async fn test_update_changelog_head_creates_missing_file() {
+        let repo = TempRepo::new();
+        let ctx = test_context(repo.path().to_path_buf(), "HEAD", "v0.1.0");
+        let parsed = test_parsed_output("### Added\n- New draft");
+        let job = Arc::new(ProgressJobBuilder::new().build());
+
+        update_changelog(&ctx, &parsed, false, &job).await.unwrap();
+
+        let result = std::fs::read_to_string(repo.path().join("CHANGELOG.md")).unwrap();
+        assert_eq!(
+            result,
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n- New draft\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_changelog_head_errors_without_unreleased_header() {
+        let repo = TempRepo::new();
+        repo.write_file("CHANGELOG.md", "# Changelog\n\n## [0.1.0]\n- Old\n");
+        let ctx = test_context(repo.path().to_path_buf(), "HEAD", "v0.1.0");
+        let parsed = test_parsed_output("### Added\n- New draft");
+        let job = Arc::new(ProgressJobBuilder::new().build());
+
+        let err = update_changelog(&ctx, &parsed, false, &job)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("does not contain ## [Unreleased] or ## Unreleased"));
+    }
+
+    #[tokio::test]
+    async fn test_update_changelog_head_dry_run_leaves_file_unchanged() {
+        let repo = TempRepo::new();
+        let original = "# Changelog\n\n## [Unreleased]\n\n### Changed\n- Old draft\n";
+        repo.write_file("CHANGELOG.md", original);
+        let ctx = test_context(repo.path().to_path_buf(), "HEAD", "v0.1.0");
+        let parsed = test_parsed_output("### Added\n- New draft");
+        let job = Arc::new(ProgressJobBuilder::new().build());
+
+        update_changelog(&ctx, &parsed, true, &job).await.unwrap();
+
+        let result = std::fs::read_to_string(repo.path().join("CHANGELOG.md")).unwrap();
+        assert_eq!(result, original);
+    }
+
     #[tokio::test]
     async fn test_update_changelog_insert() {
         let repo = TempRepo::new();
@@ -1388,6 +1673,126 @@ fn today_iso() -> String {
     format!("{y:04}-{m:02}-{d:02}")
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ChangelogSection {
+    body_start: usize,
+    body_end: usize,
+}
+
+fn is_unreleased_header(line: &str) -> bool {
+    matches!(line.trim(), "## [Unreleased]" | "## Unreleased")
+}
+
+fn is_forbidden_unreleased_target_header(line: &str) -> bool {
+    matches!(
+        line.trim(),
+        "## [Unreleased]" | "## Unreleased" | "## [HEAD]" | "## HEAD"
+    )
+}
+
+fn find_unreleased_section(contents: &str) -> miette::Result<Option<ChangelogSection>> {
+    let mut lines = Vec::new();
+    let mut offset = 0;
+    for line in contents.split_inclusive('\n') {
+        let start = offset;
+        offset += line.len();
+        lines.push((start, offset, line));
+    }
+
+    let mut unreleased_index = None;
+    for (index, (_, _, line)) in lines.iter().enumerate() {
+        if is_unreleased_header(line) && unreleased_index.replace(index).is_some() {
+            return Err(miette::miette!(
+                "CHANGELOG.md contains multiple Unreleased sections; cannot update safely."
+            ));
+        }
+    }
+
+    let Some(index) = unreleased_index else {
+        return Ok(None);
+    };
+
+    let body_start = lines[index].1;
+    let mut body_end = contents.len();
+    for (start, _, line) in lines.iter().skip(index + 1) {
+        if line.trim().starts_with("## ") {
+            body_end = *start;
+            break;
+        }
+    }
+
+    Ok(Some(ChangelogSection {
+        body_start,
+        body_end,
+    }))
+}
+
+fn normalize_generated_changelog_body(generated: &str) -> String {
+    generated
+        .lines()
+        .filter(|line| !is_forbidden_unreleased_target_header(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn new_unreleased_changelog(generated: &str) -> String {
+    let body = normalize_generated_changelog_body(generated);
+    if body.is_empty() {
+        "# Changelog\n\n## [Unreleased]\n".to_string()
+    } else {
+        format!("# Changelog\n\n## [Unreleased]\n\n{body}\n")
+    }
+}
+
+fn replace_unreleased_section(existing: &str, generated: &str) -> miette::Result<String> {
+    let Some(section) = find_unreleased_section(existing)? else {
+        return Err(miette::miette!(
+            "CHANGELOG.md exists but does not contain ## [Unreleased] or ## Unreleased; add an Unreleased section before running `communique generate HEAD --changelog`."
+        ));
+    };
+
+    let body = normalize_generated_changelog_body(generated);
+    let mut updated = existing[..section.body_start].to_string();
+    if !updated.ends_with('\n') {
+        updated.push('\n');
+    }
+
+    if !body.is_empty() {
+        updated.push('\n');
+        updated.push_str(&body);
+        updated.push('\n');
+    }
+
+    let tail = existing[section.body_end..].trim_start_matches(['\r', '\n']);
+    if !tail.is_empty() {
+        updated.push('\n');
+        updated.push_str(tail);
+    }
+
+    Ok(format!("{}\n", updated.trim_end()))
+}
+
+fn read_unreleased_section(repo_root: &Path) -> miette::Result<Option<String>> {
+    let path = repo_root.join("CHANGELOG.md");
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(crate::error::Error::Io(err).into()),
+    };
+
+    let Some(section) = find_unreleased_section(&contents)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(
+        contents[section.body_start..section.body_end]
+            .trim()
+            .to_string(),
+    ))
+}
+
 async fn update_changelog(
     ctx: &Context,
     parsed: &ParsedOutput,
@@ -1397,6 +1802,24 @@ async fn update_changelog(
     job.prop("message", "Updating CHANGELOG.md...");
 
     let changelog_path = ctx.repo_root.join("CHANGELOG.md");
+    if ctx.is_unreleased_head() {
+        debug_assert_eq!(ctx.tag, "HEAD");
+        let updated = match std::fs::read_to_string(&changelog_path) {
+            Ok(existing) => replace_unreleased_section(&existing, &parsed.changelog)?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                new_unreleased_changelog(&parsed.changelog)
+            }
+            Err(err) => return Err(crate::error::Error::Io(err).into()),
+        };
+
+        if !dry_run {
+            xx::file::write(&changelog_path, updated)?;
+            info!("wrote {}", changelog_path.display());
+        }
+
+        return Ok(());
+    }
+
     let existing = xx::file::read_to_string(&changelog_path)
         .unwrap_or_else(|_| "# Changelog\n\n## [Unreleased]\n".to_string());
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -83,7 +83,7 @@ fn normalize_release_title(title: String, display_tag: &str, raw_tag: &str) -> S
         return title;
     }
 
-    if raw_tag != display_tag && title.trim() == raw_tag {
+    if raw_tag != display_tag && (title.trim() == raw_tag || title.trim() == display_tag) {
         return format!("{display_tag}: changes");
     }
 
@@ -101,6 +101,8 @@ fn normalize_release_title(title: String, display_tag: &str, raw_tag: &str) -> S
 }
 
 pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
+    validate_generate_options(&opts)?;
+
     let job = ProgressJobBuilder::new()
         .body("{{spinner()}} {{message | flex}}")
         .prop("message", "Discovering repository...")
@@ -149,8 +151,6 @@ pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
 }
 
 async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miette::Result<Context> {
-    validate_generate_options(opts)?;
-
     let github_token = std::env::var("GITHUB_TOKEN").ok();
 
     if opts.github_release && github_token.is_none() {
@@ -443,11 +443,36 @@ mod tests {
         validate_generate_options(&opts).unwrap();
     }
 
+    #[tokio::test]
+    async fn test_run_rejects_head_github_release_before_context() {
+        let opts = GenerateOptions {
+            github_release: true,
+            config: Some(PathBuf::from(
+                "/tmp/communique-missing-config-for-validation.toml",
+            )),
+            ..test_opts("HEAD")
+        };
+
+        let err = run(opts).await.unwrap_err().to_string();
+        assert!(err.contains(
+            "--github-release cannot be used with HEAD because HEAD is an unreleased changelog target. Use --changelog, or generate notes for a real tag."
+        ));
+    }
+
     #[test]
     fn test_normalize_release_title_uses_unreleased_display_tag_for_head() {
         let title = normalize_release_title("HEAD - Draft changes".into(), "Unreleased", "HEAD");
         assert_eq!(title, "Unreleased: Draft changes");
         assert!(!title.starts_with("HEAD:"));
+    }
+
+    #[test]
+    fn test_normalize_release_title_bare_unreleased_uses_changes() {
+        let title = normalize_release_title("Unreleased".into(), "Unreleased", "HEAD");
+        assert_eq!(title, "Unreleased: changes");
+
+        let tagged = normalize_release_title("v1.0.0".into(), "v1.0.0", "v1.0.0");
+        assert_eq!(tagged, "v1.0.0: v1.0.0");
     }
 
     #[test]
@@ -1248,6 +1273,43 @@ mod tests {
     }
 
     #[test]
+    fn test_replace_unreleased_section_allows_level_two_categories() {
+        let existing = "# Changelog\n\n## [Unreleased]\n\n## Added\n- thing 1\n\n## Fixed\n- thing 2\n\n## [1.0.0] - 2026-01-01\n- old release\n";
+        let updated = replace_unreleased_section(existing, "## Added\n- replacement").unwrap();
+
+        assert_eq!(
+            updated,
+            "# Changelog\n\n## [Unreleased]\n\n## Added\n- replacement\n\n## [1.0.0] - 2026-01-01\n- old release\n"
+        );
+        assert!(!updated.contains("thing 1"));
+        assert!(!updated.contains("thing 2"));
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_stops_at_unbracketed_v_version() {
+        let existing =
+            "# Changelog\n\n## [Unreleased]\n\n## Added\n- old draft\n\n## v1.0.0\n- old release\n";
+        let updated = replace_unreleased_section(existing, "## Fixed\n- replacement").unwrap();
+
+        assert_eq!(
+            updated,
+            "# Changelog\n\n## [Unreleased]\n\n## Fixed\n- replacement\n\n## v1.0.0\n- old release\n"
+        );
+        assert!(!updated.contains("old draft"));
+    }
+
+    #[test]
+    fn test_replace_unreleased_section_preserves_linked_header() {
+        let existing = "# Changelog\n\n## [Unreleased](https://example.com/compare/v1.0.0...HEAD)\n\n- Old draft\n";
+        let updated = replace_unreleased_section(existing, "- New draft").unwrap();
+
+        assert_eq!(
+            updated,
+            "# Changelog\n\n## [Unreleased](https://example.com/compare/v1.0.0...HEAD)\n\n- New draft\n"
+        );
+    }
+
+    #[test]
     fn test_replace_unreleased_section_errors_without_unreleased_header() {
         let err = replace_unreleased_section("# Changelog\n\n## [1.0.0]\n- Old\n", "- New")
             .unwrap_err()
@@ -1276,6 +1338,15 @@ mod tests {
         assert!(!updated.contains("## [HEAD]"));
         assert!(!updated.contains("## HEAD"));
         assert!(updated.contains("### Added\n- New"));
+    }
+
+    #[test]
+    fn test_normalize_generated_changelog_body_removes_linked_head_header() {
+        let body = normalize_generated_changelog_body(
+            "## [HEAD](https://example.com/compare/v1.0.0...HEAD)\n## Added\n- New",
+        );
+
+        assert_eq!(body, "## Added\n- New");
     }
 
     #[tokio::test]
@@ -1680,14 +1751,31 @@ struct ChangelogSection {
 }
 
 fn is_unreleased_header(line: &str) -> bool {
-    matches!(line.trim(), "## [Unreleased]" | "## Unreleased")
+    let line = line.trim();
+    line == "## Unreleased" || line == "## [Unreleased]" || line.starts_with("## [Unreleased](")
 }
 
 fn is_forbidden_unreleased_target_header(line: &str) -> bool {
-    matches!(
-        line.trim(),
-        "## [Unreleased]" | "## Unreleased" | "## [HEAD]" | "## HEAD"
-    )
+    let line = line.trim();
+    line == "## Unreleased"
+        || line == "## [Unreleased]"
+        || line.starts_with("## [Unreleased](")
+        || line == "## HEAD"
+        || line == "## [HEAD]"
+        || line.starts_with("## [HEAD](")
+}
+
+fn is_version_header(line: &str) -> bool {
+    let Some(rest) = line.trim().strip_prefix("## ") else {
+        return false;
+    };
+    let rest = rest.trim_start();
+
+    rest.starts_with('[')
+        || rest.chars().next().is_some_and(|c| c.is_ascii_digit())
+        || rest
+            .strip_prefix('v')
+            .is_some_and(|s| s.chars().next().is_some_and(|c| c.is_ascii_digit()))
 }
 
 fn find_unreleased_section(contents: &str) -> miette::Result<Option<ChangelogSection>> {
@@ -1715,7 +1803,7 @@ fn find_unreleased_section(contents: &str) -> miette::Result<Option<ChangelogSec
     let body_start = lines[index].1;
     let mut body_end = contents.len();
     for (start, _, line) in lines.iter().skip(index + 1) {
-        if line.trim().starts_with("## ") {
+        if is_version_header(line) {
             body_end = *start;
             break;
         }
@@ -1754,20 +1842,16 @@ fn replace_unreleased_section(existing: &str, generated: &str) -> miette::Result
     };
 
     let body = normalize_generated_changelog_body(generated);
-    let mut updated = existing[..section.body_start].to_string();
-    if !updated.ends_with('\n') {
-        updated.push('\n');
-    }
+    let mut updated = existing[..section.body_start].trim_end().to_string();
 
     if !body.is_empty() {
-        updated.push('\n');
+        updated.push_str("\n\n");
         updated.push_str(&body);
-        updated.push('\n');
     }
 
     let tail = existing[section.body_end..].trim_start_matches(['\r', '\n']);
     if !tail.is_empty() {
-        updated.push('\n');
+        updated.push_str("\n\n");
         updated.push_str(tail);
     }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -75,6 +75,7 @@ pub struct UserPromptContext<'a> {
     pub owner_repo: &'a str,
     pub git_log: &'a str,
     pub pr_numbers: &'a [u64],
+    pub is_unreleased_head: bool,
     pub changelog_entry: Option<&'a str>,
     pub existing_release: Option<&'a str>,
     pub context: Option<&'a str>,
@@ -88,6 +89,7 @@ pub fn user_prompt(ctx: &UserPromptContext) -> String {
         owner_repo,
         git_log,
         pr_numbers,
+        is_unreleased_head,
         changelog_entry,
         existing_release,
         context,
@@ -99,8 +101,14 @@ pub fn user_prompt(ctx: &UserPromptContext) -> String {
         parts.push(format!("## Project Context\n{ctx}"));
     }
 
+    let release_request = if *is_unreleased_head {
+        format!("Generate release notes for unreleased changes since {prev_tag}.")
+    } else {
+        format!("Generate release notes for **{tag}** (previous release: {prev_tag}).")
+    };
+
     parts.push(format!(
-        "Generate release notes for **{tag}** (previous release: {prev_tag}).\n\
+        "{release_request}\n\
          Repository: `{owner_repo}` (https://github.com/{owner_repo})\n\n\
          ## Git Log\n```\n{git_log}\n```"
     ));
@@ -117,9 +125,15 @@ pub fn user_prompt(ctx: &UserPromptContext) -> String {
     }
 
     if let Some(entry) = changelog_entry {
-        parts.push(format!(
-            "\n## Existing CHANGELOG.md Entry\nHere is the current auto-generated entry — use it as a starting point and improve it:\n```\n{entry}\n```"
-        ));
+        if *is_unreleased_head {
+            parts.push(format!(
+                "\n## Existing Unreleased CHANGELOG.md Draft\nHere is the current draft unreleased material — reconcile it with the generated notes and improve it. Produce only the changelog section body, without a nested `## [Unreleased]` or `## Unreleased` heading:\n```\n{entry}\n```"
+            ));
+        } else {
+            parts.push(format!(
+                "\n## Existing CHANGELOG.md Entry\nHere is the current auto-generated entry — use it as a starting point and improve it:\n```\n{entry}\n```"
+            ));
+        }
     }
 
     if let Some(body) = existing_release {
@@ -184,6 +198,7 @@ mod tests {
             owner_repo: "jdx/communique",
             git_log: "abc1234 feat: add feature",
             pr_numbers: &[],
+            is_unreleased_head: false,
             changelog_entry: None,
             existing_release: None,
             context: None,
@@ -206,6 +221,7 @@ mod tests {
             owner_repo: "jdx/communique",
             git_log: "abc1234 feat (#42)",
             pr_numbers: &[42, 99],
+            is_unreleased_head: false,
             changelog_entry: None,
             existing_release: None,
             context: None,
@@ -225,6 +241,7 @@ mod tests {
             owner_repo: "jdx/communique",
             git_log: "def5678 fix: bug",
             pr_numbers: &[10],
+            is_unreleased_head: false,
             changelog_entry: Some("### Fixed\n- Bug fix"),
             existing_release: Some("Previous release body"),
             context: Some("This is a CLI tool for release notes."),
@@ -249,12 +266,74 @@ mod tests {
             owner_repo: "test/repo",
             git_log: "abc init",
             pr_numbers: &[],
+            is_unreleased_head: false,
             changelog_entry: None,
             existing_release: None,
             context: None,
             recent_releases: &[("v1.0.0".into(), long_body)],
         });
         assert!(prompt.contains("[truncated]"));
+    }
+
+    #[test]
+    fn test_user_prompt_unreleased_head_labels_changes_without_head() {
+        let prompt = user_prompt(&UserPromptContext {
+            tag: "HEAD",
+            prev_tag: "v1.0.0",
+            owner_repo: "test/repo",
+            git_log: "abc1234 feat: draft feature",
+            pr_numbers: &[],
+            is_unreleased_head: true,
+            changelog_entry: None,
+            existing_release: None,
+            context: None,
+            recent_releases: &[],
+        });
+
+        assert!(prompt.contains("Generate release notes for unreleased changes since v1.0.0."));
+        assert!(!prompt.contains("**HEAD**"));
+    }
+
+    #[test]
+    fn test_user_prompt_tagged_mode_preserves_tagged_phrase() {
+        let prompt = user_prompt(&UserPromptContext {
+            tag: "v2.0.0",
+            prev_tag: "v1.0.0",
+            owner_repo: "test/repo",
+            git_log: "abc1234 feat: tagged feature",
+            pr_numbers: &[],
+            is_unreleased_head: false,
+            changelog_entry: None,
+            existing_release: None,
+            context: None,
+            recent_releases: &[],
+        });
+
+        assert!(
+            prompt.contains("Generate release notes for **v2.0.0** (previous release: v1.0.0).")
+        );
+    }
+
+    #[test]
+    fn test_user_prompt_unreleased_changelog_entry_is_draft_material() {
+        let prompt = user_prompt(&UserPromptContext {
+            tag: "HEAD",
+            prev_tag: "v1.0.0",
+            owner_repo: "test/repo",
+            git_log: "abc1234 feat: draft feature",
+            pr_numbers: &[],
+            is_unreleased_head: true,
+            changelog_entry: Some("### Changed\n- Old draft"),
+            existing_release: None,
+            context: None,
+            recent_releases: &[],
+        });
+
+        assert!(prompt.contains("Existing Unreleased CHANGELOG.md Draft"));
+        assert!(prompt.contains("draft unreleased material"));
+        assert!(prompt.contains("without a nested `## [Unreleased]` or `## Unreleased` heading"));
+        assert!(!prompt.contains("Existing CHANGELOG.md Entry"));
+        assert!(!prompt.contains("**HEAD**"));
     }
 
     #[test]
@@ -270,6 +349,7 @@ mod tests {
             owner_repo: "test/repo",
             git_log: "abc init",
             pr_numbers: &[],
+            is_unreleased_head: false,
             changelog_entry: None,
             existing_release: None,
             context: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -99,6 +99,108 @@ async fn test_generate_end_to_end() {
     );
 }
 
+#[tokio::test]
+async fn test_generate_head_changelog_updates_unreleased() {
+    let server = wiremock::MockServer::start().await;
+
+    wiremock::Mock::given(wiremock::matchers::method("POST"))
+        .and(wiremock::matchers::path("/chat/completions"))
+        .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "message": {
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "submit_release_notes",
+                            "arguments": serde_json::to_string(&json!({
+                                "changelog": "### Added\n- Unreleased feature",
+                                "release_title": "HEAD - Draft Feature",
+                                "release_body": "Draft feature release notes."
+                            })).unwrap()
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": {"prompt_tokens": 80, "completion_tokens": 40}
+        })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    git(repo, &["init"]);
+    git(repo, &["config", "user.email", "test@test.com"]);
+    git(repo, &["config", "user.name", "Test"]);
+
+    std::fs::write(repo.join("README.md"), "# hello").unwrap();
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-m", "initial"]);
+    git(repo, &["tag", "v0.1.0"]);
+
+    std::fs::write(repo.join("feature.rs"), "// feature").unwrap();
+    std::fs::write(
+        repo.join("CHANGELOG.md"),
+        "# Changelog\n\n## [Unreleased]\n\n### Changed\n- Old draft\n\n## [0.1.0] - 2026-01-01\n### Added\n- Initial release\n",
+    )
+    .unwrap();
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-m", "add unreleased feature"]);
+
+    let output_file = repo.join("output.md");
+    let bin = env!("CARGO_BIN_EXE_communique");
+
+    let result = Command::new(bin)
+        .current_dir(repo)
+        .args([
+            "generate",
+            "HEAD",
+            "--changelog",
+            "--repo",
+            "test/repo",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+            "--base-url",
+            &server.uri(),
+            "--output",
+            output_file.to_str().unwrap(),
+        ])
+        .env("OPENAI_API_KEY", "test-key")
+        .env("CLX_NO_PROGRESS", "1")
+        .env_remove("GITHUB_TOKEN")
+        .output()
+        .expect("failed to run communique");
+
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(result.status.success(), "communique failed: {}", stderr);
+
+    let changelog = std::fs::read_to_string(repo.join("CHANGELOG.md")).unwrap();
+    assert!(
+        changelog.contains("## [Unreleased]\n\n### Added\n- Unreleased feature"),
+        "changelog: {changelog}"
+    );
+    assert!(
+        changelog.contains("## [0.1.0] - 2026-01-01\n### Added\n- Initial release"),
+        "changelog should preserve released sections: {changelog}"
+    );
+    assert!(!changelog.contains("## [HEAD]"));
+    assert!(!changelog.contains("## HEAD"));
+
+    let output = std::fs::read_to_string(&output_file).unwrap();
+    assert!(
+        output.contains("# Unreleased: Draft Feature"),
+        "output: {output}"
+    );
+    assert!(
+        !output.contains("HEAD:"),
+        "output should not expose HEAD label: {output}"
+    );
+}
+
 /// Same as above but with `--concise` to verify changelog-only output.
 #[tokio::test]
 async fn test_generate_concise() {


### PR DESCRIPTION
Hey jdx, really cool project, thanks for kicking it off. What do you think of allowing someone to generate a changelog entry for all unreleased entries if they generate changelogs off HEAD? I took the liberty of cooking up a PoC in this PR. Below are the agent's PR description and plan used to cook this up.

---

## Summary

Make `communique generate HEAD --changelog` an intentional way to produce/refresh the `[Unreleased]` section of `CHANGELOG.md`, instead of writing a literal `## [HEAD]` entry.

Today the command already collects the right git range (latest tag → `HEAD`), but it labels the result as a release named `HEAD` and inserts `## [HEAD]` into the changelog. This PR keeps the existing range mechanics and instead routes `HEAD` to "Unreleased" semantics end-to-end.

## Motivation

When iterating on unreleased work, it's useful to regenerate the `[Unreleased]` block from current `main` without first creating a tag or hand-editing the changelog. A literal `## [HEAD]` heading is never what a user wants — but the rest of the pipeline is already a great fit, so the change is mostly a matter of relabeling and a deterministic in-place changelog edit.

## Behavior

- `communique generate HEAD --changelog`
  - Replaces the body of the existing `## [Unreleased]` (or `## Unreleased`) section in place.
  - Preserves the file preamble, the exact unreleased header text as found, and all released sections that follow.
  - If `CHANGELOG.md` doesn't exist, creates it with `# Changelog`, `## [Unreleased]`, and the generated body.
  - If an existing `CHANGELOG.md` has no Unreleased header, fails with an actionable `miette` diagnostic instead of guessing where to insert content.
- Prompts and user-facing labels in `HEAD` mode read as "unreleased changes since {prev_tag}" rather than `**HEAD**`. Existing `[Unreleased]` content is passed in as draft material to reconcile, and the model is instructed not to emit a nested `## [Unreleased]` heading.
- `communique generate HEAD --github-release` now fails fast with a clear message — `HEAD` is not a release tag and shouldn't be searched for/updated on GitHub.
- Tagged-release behavior (`vX.Y.Z --changelog`, `vX.Y.Z --github-release`, prompt phrasing, title normalization) is unchanged.

The literal `unreleased` CLI argument is intentionally **not** added in this PR; `HEAD` is the only new entry point.

## Implementation notes

- New helpers on `Context`: `is_unreleased_head()` and `display_tag()` to keep the literal `HEAD` from leaking into user-facing output while preserving `ctx.tag` for git ref usage.
- Deterministic, line-based `[Unreleased]` section replacement — no second LLM call to merge the section. Handles both `## [Unreleased]` and `## Unreleased` headers.
- `--github-release` guard runs early, before any GitHub API call.
- `debug_assert!`s used only for internal invariants in the HEAD-only branch; user-facing failure modes use `miette` errors.

## Files touched

| File | Net | Purpose |
| --- | --- | --- |
| `src/generate.rs` | +463 | Helpers, HEAD branch in `update_changelog`, deterministic section replacer, `--github-release` guard, focused unit tests |
| `src/prompt.rs` | +88 | `is_unreleased_head` prompt context + unreleased phrasing |
| `tests/integration.rs` | +102 | New mocked end-to-end test `test_generate_head_changelog_updates_unreleased` |

## Testing

New tests:

- `test_update_changelog_head_updates_unreleased_in_place`
- `test_update_changelog_head_creates_missing_file`
- `test_update_changelog_head_errors_without_unreleased_header`
- `test_update_changelog_head_dry_run_leaves_file_unchanged`
- `test_generate_head_changelog_updates_unreleased` (integration, wiremock)

Validation run locally:

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ — 146 unit + 3 integration tests pass

Existing changelog and tagged-release tests continue to pass unchanged.

## Out of scope

- Literal `unreleased` CLI argument.
- Changes to `src/git.rs` range behavior — the existing `previous_tag(... "HEAD")` fallback to the most recent tag and `resolve_ref("HEAD")` already do the right thing for this feature.
- Any unrelated prompt/changelog refactors.

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` update

## Goal

Make the existing `HEAD` route an intentional way to generate unreleased changelog content:

```sh
communique generate HEAD --changelog
```

Expected behavior:

- Keep using existing git behavior to collect changes from the latest tag / explicit previous tag to `HEAD`.
- Treat `HEAD` as an unreleased target for display, prompt, and changelog behavior.
- Update the existing `## [Unreleased]` / `## Unreleased` section instead of inserting a literal `## [HEAD]` release entry.
- Do **not** add support for the literal `unreleased` argument in this change.

## Current evidence

<details>
<summary>Verified behavior from repo investigation</summary>

- `src/cli.rs` accepts `generate <tag>` as a required string argument; there is no special `unreleased` mode.
- `src/git.rs::previous_tag(repo_root, "HEAD")` does not find a tag named `HEAD`, then falls back to the most recent tag. This already gives the desired base tag when no previous tag override is supplied.
- `src/git.rs::resolve_ref(repo_root, "HEAD")` resolves `HEAD` as a valid git ref, giving the desired comparison end ref.
- `src/generate.rs::gather_context` stores the literal tag string in `Context.tag`.
- `src/prompt.rs::user_prompt` currently phrases the request as generating release notes for the literal tag, so `HEAD` appears as the release label.
- `src/generate.rs::update_changelog` currently uses `Context.tag` as the version identifier when inserting changelog content, so `HEAD --changelog` would create a literal `## [HEAD]`-style entry rather than updating `[Unreleased]`.
- `src/generate.rs` already has changelog tests covering insertion, new-file creation, dry-run behavior, and tail preservation.
- `tests/integration.rs` uses `wiremock`; unit tests use `MockLlmClient` / `TempRepo`, so the change can be validated without real API keys.

</details>

## Scope and non-goals

### In scope

1. Add intentional `HEAD` target handling for generated labels and changelog updates.
2. Preserve the existing git range mechanics.
3. Add focused tests for `HEAD --changelog`.
4. Add a clear guard for unsupported `HEAD --github-release` usage.
5. Keep changes surgical and preserve normal tagged release behavior.

### Out of scope

- Supporting `communique generate unreleased`.
- Reworking release-note generation architecture.
- Changing normal `communique generate vX.Y.Z --changelog` behavior.
- Publishing GitHub releases for `HEAD`.

## Proposed implementation

### Phase 1 — Introduce a small target-mode helper

Add the smallest explicit abstraction needed to avoid leaking the literal `HEAD` into user-facing release labels.

Preferred minimal shape in `src/generate.rs`:

```rust
impl Context {
    fn is_unreleased_head(&self) -> bool {
        self.tag == "HEAD"
    }

    fn display_tag(&self) -> &str {
        if self.is_unreleased_head() {
            "Unreleased"
        } else {
            &self.tag
        }
    }
}
```

Rationale:

- Avoids adding a stored boolean that can drift out of sync with `Context.tag`.
- Keeps git/ref behavior unchanged: code that needs the actual ref should keep using `ctx.tag`.
- User-facing output, prompt text, and changelog mode can use `ctx.display_tag()` / `ctx.is_unreleased_head()`.

Quality gate after this phase:

- Compile the touched module/tests if possible: `cargo test --lib generate::` or the closest available focused test command.

### Phase 2 — Keep git range behavior unchanged

Do **not** change `src/git.rs` unless a focused test reveals a regression.

Implementation expectation:

- `communique generate HEAD` with no explicit previous tag continues to resolve the base as the latest tag via existing `previous_tag` fallback.
- `HEAD` continues to resolve as the end ref via existing `resolve_ref`.
- If the CLI supports an explicit previous tag override, preserve it for `HEAD`, e.g. `communique generate HEAD v1.0.3` should use `v1.0.3..HEAD`.

Add/adjust tests only if there is no direct coverage for the assumptions above:

- `previous_tag(repo_root, "HEAD")` returns the newest version tag in a tagged fixture.
- `resolve_ref(repo_root, "HEAD")` returns the current commit SHA / valid ref.

Quality gate after this phase:

```sh
cargo test previous_tag resolve_ref
```

If test names differ, run the relevant `src/git.rs` test subset or `cargo test --lib git`.

### Phase 3 — Update prompt and display labels for `HEAD`

In `src/prompt.rs`:

1. Add a boolean field to `UserPromptContext`, for example:

   ```rust
   pub is_unreleased_head: bool
   ```

2. When true, phrase the request as unreleased work since the previous tag, not as a release named `HEAD`.

   Example intent, not exact final copy:

   ```text
   Generate release notes for unreleased changes since v1.0.4.
   ```

3. Ensure the prompt does not contain `**HEAD**` as the release version in unreleased-head mode.

In `src/generate.rs` output/title handling:

- Use `ctx.display_tag()` anywhere the user-facing label is assembled.
- Keep using `ctx.tag` anywhere a git ref is required.
- Skip or adjust existing title normalization that forces titles into `{tag}: ...` format so it does not produce `HEAD: ...`.

Quality gate after this phase:

- Add prompt unit tests:
  - `HEAD` mode says “unreleased” and includes the previous tag.
  - `HEAD` mode does not label the release as `**HEAD**`.
  - Normal tag mode still says `**vX.Y.Z**`.

### Phase 4 — Branch changelog updates for `HEAD --changelog`

In `src/generate.rs::update_changelog`, branch early when `ctx.is_unreleased_head()` is true.

Normal tag behavior remains unchanged:

```text
## [Unreleased]

## [v1.0.4] - YYYY-MM-DD
...
```

New `HEAD` behavior:

```text
## [Unreleased]
<replace/update this section with generated changelog content>

## [v1.0.4] - YYYY-MM-DD
...
```

Recommended helper:

```rust
fn replace_unreleased_section(existing: &str, generated: &str) -> miette::Result<String>
```

Helper requirements:

- Work line-by-line rather than with fragile substring offsets.
- Accept both `## [Unreleased]` and `## Unreleased` headers, matching existing project parsing behavior.
- Preserve the exact unreleased header text found in the file.
- Preserve the file preamble and all released sections after the unreleased section.
- Replace only the body between the unreleased header and the next top-level `## ` heading.
- Normalize spacing to a predictable, readable form:

  ```md
  ## [Unreleased]

  ### Added
  - New item

  ## [v1.0.4] - 2026-04-01
  ```

- If `CHANGELOG.md` does not exist, keep the existing default creation behavior but populate the new `[Unreleased]` section.
- If an existing `CHANGELOG.md` lacks any Unreleased header, fail with a clear diagnostic instead of guessing where to insert it. This avoids silently corrupting nonstandard changelog layouts.

Defensive programming notes:

- Add `debug_assert!(ctx.is_unreleased_head())` inside the `HEAD`-only branch/helper caller where appropriate.
- Assert in tests that no `## [HEAD]`, `## HEAD`, or `HEAD:` changelog heading is introduced.
- Keep error handling user-facing for malformed/missing changelog sections; reserve assertions for impossible internal states.

Quality gate after this phase:

- Focused changelog tests pass.
- Existing normal-version changelog tests still pass unchanged.

### Phase 5 — Handle existing `[Unreleased]` context safely

Check `src/generate.rs::read_changelog_entry` / call sites used before LLM generation.

If the current code tries to read a changelog entry by `ctx.tag`, update the caller so that `HEAD` mode reads the existing `[Unreleased]` section instead of looking for `[HEAD]`.

Prompt behavior should make the intent clear:

- Existing `[Unreleased]` content is current draft material to reconcile/improve.
- The LLM should return the complete desired `[Unreleased]` section body, not a nested `## [Unreleased]` heading.

Acceptance test options:

- Unit test the section reader/helper if practical.
- Prompt test verifies existing unreleased content is described as unreleased draft content, not as an existing release entry for `HEAD`.

### Phase 6 — Reject unsupported GitHub release publishing for `HEAD`

Add an early guard for:

```sh
communique generate HEAD --github-release
```

Recommended behavior:

- Return a clear error before trying to fetch/update a GitHub release tagged `HEAD`.
- Suggested diagnostic:

  ```text
  --github-release cannot be used with HEAD because HEAD is an unreleased changelog target. Use --changelog, or generate notes for a real tag.
  ```

Reasoning:

- `HEAD` is not a release tag.
- Current behavior would search for a GitHub release tagged `HEAD`, which is misleading.
- This keeps the new `HEAD` mode scoped to unreleased notes/changelog content.

Quality gate after this phase:

- Add a CLI/options-level or generation-level test for the guard if the project has an easy pattern for this.
- Ensure normal `vX.Y.Z --github-release` behavior remains untouched.

## Tests to add/update

### Unit tests in `src/generate.rs`

Add focused tests around the deterministic changelog helper and `update_changelog` path:

1. `test_replace_unreleased_section_bracketed_header`
   - Input has `## [Unreleased]` followed by a released version.
   - Output replaces only the unreleased body.
   - Released version content remains unchanged.
   - No `HEAD` heading is present.

2. `test_replace_unreleased_section_plain_header`
   - Same as above, but with `## Unreleased`.

3. `test_update_changelog_head_updates_unreleased_section`
   - Build `Context { tag: "HEAD", ... }`.
   - Use `ParsedOutput.changelog` with generated section body.
   - Verify `CHANGELOG.md` updates `[Unreleased]` in place.

4. `test_update_changelog_head_new_file_creates_unreleased_section`
   - No existing `CHANGELOG.md`.
   - Verify resulting file has `# Changelog`, `## [Unreleased]`, generated body, and no `## [HEAD]`.

5. `test_update_changelog_head_missing_unreleased_errors`
   - Existing changelog has released entries but no `Unreleased` heading.
   - Verify actionable error.

6. Existing normal changelog tests continue to pass:
   - Insert new version after `[Unreleased]` for real tags.
   - Dry-run does not write.
   - Tail preservation still works.

### Unit tests in `src/prompt.rs`

1. `test_user_prompt_unreleased_head_mode`
   - `tag = "HEAD"`, `prev_tag = "v1.0.4"`, `is_unreleased_head = true`.
   - Prompt contains “unreleased” and `v1.0.4`.
   - Prompt does not contain `**HEAD**`.

2. `test_user_prompt_tagged_release_mode_still_uses_tag`
   - `tag = "v1.0.5"`, `is_unreleased_head = false`.
   - Prompt still contains `**v1.0.5**` and previous release text.

### Integration test in `tests/integration.rs` if practical

Add or extend a wiremock-backed test that runs the CLI with:

```sh
communique generate HEAD --changelog --repo test/repo --provider openai --base-url <mock>
```

Verify:

- The command succeeds.
- `CHANGELOG.md` has updated `[Unreleased]` content.
- No literal `HEAD` changelog heading is created.
- Latest tagged release section remains below `[Unreleased]`.

If an integration test is too expensive for the first patch, keep it as a follow-up and rely on the unit tests plus existing integration coverage.

## Acceptance criteria

- `communique generate HEAD` still uses the latest tag / explicit previous tag as the lower bound and `HEAD` as the upper bound.
- `communique generate HEAD --changelog` updates `## [Unreleased]` / `## Unreleased` in place.
- `communique generate HEAD --changelog` never inserts a literal `## [HEAD]` / `## HEAD` changelog section.
- User-facing generated labels avoid `HEAD` and use “Unreleased” / “unreleased changes” wording.
- Normal tagged release generation is unchanged.
- `communique generate HEAD --github-release` fails with a clear message.
- New behavior is covered by unit tests, and normal changelog tests continue to pass.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` pass.

## Dogfooding and quality gates

### Automated quality gates between implementation phases

After changing prompt/display behavior:

```sh
cargo test --lib prompt
```

After changing changelog helpers:

```sh
cargo test --lib update_changelog
cargo test --lib replace_unreleased
```

If exact test filters differ, use the closest matching filters or run:

```sh
cargo test --lib
```

Before final handoff:

```sh
cargo fmt --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test
```

If the repository expects the project wrapper, also run:

```sh
mise run lint
```

### Manual dogfooding recipe

Use a temporary git repository so no real project history or GitHub release is touched.

1. Build the local binary:

   ```sh
   cargo build
   ```

2. Create a temporary repo:

   ```sh
   TMP_DIR=$(mktemp -d)
   cd "$TMP_DIR"
   git init
   git config user.email "test@example.com"
   git config user.name "Test User"
   cat > CHANGELOG.md <<'EOF'
   # Changelog

   ## [Unreleased]

   ## [v1.0.4] - 2026-04-01
   ### Fixed
   - Previous released fix.
   EOF
   git add CHANGELOG.md
   git commit -m "chore: seed changelog"
   git tag v1.0.4
   echo "new behavior" > feature.txt
   git add feature.txt
   git commit -m "feat: add unreleased behavior"
   ```

3. Run the CLI against a mocked OpenAI-compatible endpoint using the existing `wiremock` integration-test pattern, or run against a real provider only if API keys are intentionally available.

   Example shape:

   ```sh
   /path/to/communique generate HEAD \
     --changelog \
     --repo test/repo \
     --provider openai \
     --model test-model \
     --base-url http://127.0.0.1:<mock-port> \
     --output notes.md
   ```

4. Verify the result:

   ```sh
   grep -n "Unreleased\|HEAD\|v1.0.4" CHANGELOG.md
   git diff -- CHANGELOG.md notes.md
   ```

   Expected:

   - `## [Unreleased]` contains the generated unreleased notes.
   - `## [v1.0.4]` remains below it.
   - No `## [HEAD]` / `## HEAD` section appears.
   - `notes.md` describes unreleased changes rather than a release named `HEAD`.

5. Negative dogfood:

   ```sh
   /path/to/communique generate HEAD --github-release --repo test/repo
   ```

   Expected: clear error explaining that `--github-release` cannot be used with `HEAD`.

### Evidence capture for reviewer

Because this is a CLI change, capture terminal evidence rather than browser screenshots:

- Record the manual dogfood session with `asciinema rec` if available, or with `script` as a fallback.
- Capture screenshots of:
  1. The temp repo setup and tag state (`git log --oneline --decorate --graph`).
  2. The successful `generate HEAD --changelog` run.
  3. The resulting `git diff -- CHANGELOG.md notes.md` showing `[Unreleased]` updated and no `[HEAD]` entry.
  4. The `HEAD --github-release` error.
- Attach the screenshots/video recording to the final implementation handoff if the environment supports attachments.

## Risks and mitigations

| Risk | Mitigation |
| --- | --- |
| Existing `[Unreleased]` content could be overwritten unexpectedly. | Make prompt include existing section content when available; document/test that the generated body replaces the section body. This mirrors “regenerate this section” semantics. |
| Changelog without an Unreleased section could be rearranged incorrectly. | Fail with a clear diagnostic for existing files missing the section; only auto-create when the file itself does not exist. |
| `HEAD` leaks into output titles or prompts. | Centralize label choice via `display_tag()` and add prompt/output tests that reject `HEAD` labels in unreleased mode. |
| Normal tag releases regress. | Keep branch condition narrowly scoped to `ctx.tag == "HEAD"`; rerun existing changelog and integration tests. |
| `--github-release` with `HEAD` behaves misleadingly. | Add an early explicit error. |

## Handoff notes for implementation

- Keep the diff small and avoid refactoring unrelated prompt/changelog code.
- Prefer deterministic changelog section replacement over a second LLM merge step for the `[Unreleased]` file edit.
- Match existing formatting style and error types in `src/generate.rs`.
- Use assertions only for internal invariants; use user-facing `miette` errors for malformed/missing changelog input.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-opus-4-7` • Thinking: `max`_
