### PR TITLE
v1.1.0: HEAD as [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/jdx/communique/releases/tag/v1.1.0) - 2026-04-26
+
+## Added
+
+- *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
+
 ## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 
 ## Fixed
 
 - **agent**: salvage partial `submit_release_notes` calls and surface better diagnostics instead of hard-failing after 3 malformed attempts ([#120](https://github.com/jdx/communique/pull/120))
-- **docs**: stack the announcement banner and pin the close button to the top-right on mobile viewports ([#119](https://github.com/jdx/communique/pull/119))
-
-## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
+- **docs**: stack the announcement banner and pin the close button to the top-right on mobile viewports ([#119](https://github.com/jdx/communique/pull/119))## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.0.4"
+version = "1.1.0"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.0.4"
+version "1.1.0"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.0.4",
+  "version": "1.1.0",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.0.4
+**Version**: 1.1.0
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small feature release that turns `communique generate HEAD --changelog` into a first-class way to refresh the `[Unreleased]` section of `CHANGELOG.md` without first cutting a tag.

## Added

- **`HEAD --changelog` updates `[Unreleased]` in place** — Previously, running `communique generate HEAD --changelog` would carry the literal `HEAD` through the pipeline and insert a `## [HEAD]` heading into `CHANGELOG.md`, which is never what anyone wants. The command now treats `HEAD` as an intentional unreleased target end-to-end:
  - The existing `## [Unreleased]` (or `## Unreleased`, including linked variants like `## [Unreleased](…/compare/v1.0.0...HEAD)`) section body is replaced deterministically — no second LLM merge step — while the file preamble, the unreleased header text, and all released sections below are preserved exactly.
  - If `CHANGELOG.md` doesn't exist, it's created with `# Changelog`, `## [Unreleased]`, and the generated body.
  - If an existing `CHANGELOG.md` has no Unreleased header, the command fails with an actionable `miette` diagnostic instead of guessing where to insert content. Multiple Unreleased sections are also rejected rather than silently corrupted.
  - The current `[Unreleased]` content is fed into the prompt as draft material to reconcile, and the model is explicitly told not to emit a nested `## [Unreleased]` heading. Any `## [HEAD]` / `## HEAD` headings the model produces anyway are stripped before writing.
  - Prompt phrasing switches from `Generate release notes for **HEAD** (previous release: v1.0.4)` to `Generate release notes for unreleased changes since v1.0.4`, and the release title is normalized to `Unreleased: <description>` instead of `HEAD: …`.
  - `communique generate HEAD --github-release` now fails fast with a clear error — `HEAD` is not a release tag and shouldn't be searched for or published on GitHub. Use `--changelog` instead, or generate notes for a real tag.

  ```sh
  # Refresh the [Unreleased] block from current main, no tag required:
  communique generate HEAD --changelog
  ```

  Tagged-release behavior (`vX.Y.Z --changelog`, `vX.Y.Z --github-release`, prompt phrasing, title normalization) is unchanged. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)

## New Contributors

* @ThomasK33 made their first contribution in [#121](https://github.com/jdx/communique/pull/121)

## 💚 Sponsor communique

communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata/doc updates only (version bumps and changelog/docs regeneration) with no runtime logic changes, so impact is low risk.
> 
> **Overview**
> Bumps the crate/CLI version from `1.0.4` to `1.1.0` across `Cargo.toml`, `Cargo.lock`, the usage spec, and generated CLI docs.
> 
> Updates `CHANGELOG.md` with a new `1.1.0` entry describing `generate HEAD --changelog` treating `HEAD` as an *intentional* `[Unreleased]` target and rejecting `HEAD --github-release`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ea14e93a5fccfe2acc354a93990bc2f37130df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->