### PR TITLE
fix(release): dedupe sponsor release notes

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -105,9 +105,11 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
-          {
-            gh release view "$TAG" --json body --jq .body
-            cat <<'EOF'
+          gh release view "$TAG" --json body --jq .body \
+            | perl -0pe 's/\n*##\s+💚?\s*Sponsor communique\b.*\z//s' \
+            > /tmp/release-notes.md
+
+          cat <<'EOF' >> /tmp/release-notes.md
 
           ## 💚 Sponsor communique
 
@@ -115,7 +117,7 @@ jobs:
 
           If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.
           EOF
-          } > /tmp/release-notes.md
+
           gh release edit "$TAG" --notes-file /tmp/release-notes.md
 
   release-plz-pr:


### PR DESCRIPTION
Make the release sponsor append step idempotent by removing any existing communique sponsor section before appending the canonical en.dev blurb. This prevents communique-generated sponsor text and workflow reruns from producing duplicate sponsor release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; it only adjusts how the GitHub Actions job edits release notes to avoid duplicated sponsor text on reruns.
> 
> **Overview**
> Makes the `Append en.dev sponsor blurb` step in `.github/workflows/release-plz.yml` idempotent by stripping any existing `## 💚 Sponsor communique` section from the current GitHub release body before appending the canonical sponsor blurb and updating the release notes file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cca86ab0cb4b4de89492d2d432458177ab830c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->