### PR TITLE
v1.1.1: Less repetitive release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/jdx/communique/releases/tag/v1.1.1) - 2026-04-26
+
+## Fixed
+
+- Reduce repetitive Highlights in generated release notes by tightening the system prompt and tool schema ([#124](https://github.com/jdx/communique/pull/124))
+- Dedupe the sponsor blurb in communique's own GitHub releases when the workflow re-runs ([#123](https://github.com/jdx/communique/pull/123))
+
 ## [1.1.0](https://github.com/jdx/communique/releases/tag/v1.1.0) - 2026-04-26
 
 ## Added
 
-- *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
-
-## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
+- *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 
 ## Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.1.0"
+version "1.1.1"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.0
+**Version**: 1.1.1
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that stops generated release notes from saying the same thing three times, and keeps communique's own sponsor footer from compounding on workflow reruns.

## Fixed

- **Reserve Highlights for genuinely broad releases** — The release-note system prompt and the `submit_release_notes` tool schema have been retightened so the model stops producing a `## Highlights` section that just restates the categorized `## Added` / `## Fixed` bullets underneath it. The opening summary is now capped at 1-2 sentences, Highlights are gated on "roughly 10+ distinct user-facing changes or 4+ independent headline themes", and the prompt explicitly assigns each section a distinct job: the opening paragraph frames the release, Highlights (when present) group broad themes for skimming, and categorized sections carry the concrete PR links, authors, examples, and compatibility notes. The prompt also tells the model directly to avoid saying the same change three times. Patch and small minor releases should now skip Highlights entirely instead of padding them out. ([#124](https://github.com/jdx/communique/pull/124)) (@jdx)
- **Dedupe the sponsor blurb on release reruns** — communique's own `release-plz` workflow appends a `## 💚 Sponsor communique` footer to each GitHub release. If the workflow re-ran, or if communique itself drafted notes that already included a sponsor section, the footer would stack up. The `Append en.dev sponsor blurb` step is now idempotent: it strips any existing `## 💚 Sponsor communique` section from the current release body before appending the canonical en.dev blurb. ([#123](https://github.com/jdx/communique/pull/123)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps version metadata and updates generated documentation/changelog; no runtime behavior changes are included in the diff (aside from a potential `CHANGELOG.md` formatting glitch).
> 
> **Overview**
> Cuts the `v1.1.1` release by bumping the crate/CLI version from `1.1.0` → `1.1.1` across `Cargo.toml`, `Cargo.lock`, the usage spec, and generated CLI docs.
> 
> Updates `CHANGELOG.md` with a new `1.1.1` entry describing two fixes, though the edit also leaves a **formatting issue** where the `1.1.0` entry appears to run into the `1.0.4` header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82507c29a2274a617e4dbe18b29fbb5cbd8dc78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->