### PR TITLE
fix(generate): preserve changelog section boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
+- *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
+
+## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 
 ## Fixed
 
 - **agent**: salvage partial `submit_release_notes` calls and surface better diagnostics instead of hard-failing after 3 malformed attempts ([#120](https://github.com/jdx/communique/pull/120))
-- **docs**: stack the announcement banner and pin the close button to the top-right on mobile viewports ([#119](https://github.com/jdx/communique/pull/119))## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
+- **docs**: stack the announcement banner and pin the close button to the top-right on mobile viewports ([#119](https://github.com/jdx/communique/pull/119))
+
+## [1.0.3](https://github.com/jdx/communique/compare/v1.0.2...v1.0.3) - 2026-04-23
 
 ### Fixed
 
@@ -37,7 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add cross-site announcement banner ([#109](https://github.com/jdx/communique/pull/109))
 - *(release)* append en.dev sponsor blurb to release notes ([#106](https://github.com/jdx/communique/pull/106))
 
-## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21## Fixed
+## [1.0.2](https://github.com/jdx/communique/releases/tag/v1.0.2) - 2026-04-21
+
+## Fixed
 
 - Retry malformed `submit_release_notes` tool calls instead of aborting the run, with a cap of 3 attempts ([#105](https://github.com/jdx/communique/pull/105))
 
@@ -45,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Bumped the default model from `claude-opus-4-6` to `claude-opus-4-7` ([#101](https://github.com/jdx/communique/pull/101))## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
+- Bumped the default model from `claude-opus-4-6` to `claude-opus-4-7` ([#101](https://github.com/jdx/communique/pull/101))
+
+## [1.0.0](https://github.com/jdx/communique/compare/v0.1.9...v1.0.0) - 2026-04-19
 
 ### Changed
 
@@ -69,7 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(deps)* update rust crate clap to v4.5.60 ([#59](https://github.com/jdx/communique/pull/59))
 - *(deps)* pin dependencies ([#58](https://github.com/jdx/communique/pull/58))
 - *(deps)* update rust crate futures-util to v0.3.32 ([#56](https://github.com/jdx/communique/pull/56))
-- run render and lint-fix when creating release PR ([#53](https://github.com/jdx/communique/pull/53))## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
+- run render and lint-fix when creating release PR ([#53](https://github.com/jdx/communique/pull/53))
+
+## [0.1.8](https://github.com/jdx/communique/releases/tag/v0.1.8) - 2026-02-18
 
 ### Added
 
@@ -77,7 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Propagated errors from the list releases API call in the `get_release_by_tag` fallback instead of silently swallowing them, fixing misleading "No GitHub release found" messages ([#49](https://github.com/jdx/communique/pull/49))## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
+- Propagated errors from the list releases API call in the `get_release_by_tag` fallback instead of silently swallowing them, fixing misleading "No GitHub release found" messages ([#49](https://github.com/jdx/communique/pull/49))
+
+## [0.1.7](https://github.com/jdx/communique/compare/v0.1.6...v0.1.7) - 2026-02-17
 
 ### Other
 
@@ -86,7 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6](https://github.com/jdx/communique/releases/tag/v0.1.6) - 2026-02-12
 
 ### Fixed
-- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45))## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
+- Fixed draft release tags getting an `untagged-*` placeholder, which prevented pre-built binaries from being uploaded to GitHub releases ([#45](https://github.com/jdx/communique/pull/45))
+
+## [0.1.5](https://github.com/jdx/communique/releases/tag/v0.1.5) - 2026-02-12
 
 ### Changed
 - Regenerated CLI documentation to reflect flags and options added in prior releases ([#43](https://github.com/jdx/communique/pull/43))
@@ -97,7 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased retry resilience for transient API failures — retries now use 10 attempts with a 1s initial delay and 60s max backoff (up from 5 attempts / 500ms / 30s), improving reliability during API outages ([#41](https://github.com/jdx/communique/pull/41))
 
 ### Fixed
-- Fixed double tag prefix in release PR titles where both the workflow and generate logic prepended the tag ([#41](https://github.com/jdx/communique/pull/41))## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
+- Fixed double tag prefix in release PR titles where both the workflow and generate logic prepended the tag ([#41](https://github.com/jdx/communique/pull/41))
+
+## [0.1.3](https://github.com/jdx/communique/releases/tag/v0.1.3) - 2026-02-12
 
 ### Fixed
 - Fix draft release lookup — `get_release_by_tag` now falls back to listing releases when the `/releases/tags` endpoint returns 404, since that endpoint doesn't return draft releases ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
@@ -107,11 +123,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated GitHub Actions documentation to show `--changelog` usage, the required `git fetch --tags` step, and simplified workflow examples ([f201231](https://github.com/jdx/communique/commit/f2012318af310105f0a2517b2c6ad03ce684f176))
 
 ### Removed
-- macOS x86_64 pre-built binaries are no longer published; only aarch64 (Apple Silicon) binaries are provided for macOS ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
+- macOS x86_64 pre-built binaries are no longer published; only aarch64 (Apple Silicon) binaries are provided for macOS ([2861482](https://github.com/jdx/communique/commit/28614828b1561ae198943e9f290b4c27be4c8a38))
+
+## [0.1.2](https://github.com/jdx/communique/compare/v0.1.1...v0.1.2) - 2026-02-12
 
 ### Other
 
-- Prefix release titles with tag and use draft releases## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12## Added
+- Prefix release titles with tag and use draft releases
+
+## [0.1.1](https://github.com/jdx/communique/compare/v0.1.0...v0.1.1) - 2026-02-12
+
+## Added
 - Multi-model LLM support with OpenAI-compatible provider — use GPT-4, Groq, Together, Ollama, or any OpenAI-compatible API via `--provider` and `--base-url` flags
 - `--dry-run` (`-n`) flag to preview release notes without updating GitHub or verifying links
 - `--verbose` (`-v`) and `--quiet` (`-q`) flags for controlling output verbosity

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -761,6 +761,21 @@ mod tests {
     }
 
     #[test]
+    fn test_read_changelog_entry_allows_level_two_categories() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("CHANGELOG.md"),
+            "## [1.0.0]\n## Added\n- Feature\n\n## Fixed\n- Bug\n\n## [0.9.0]\n## Fixed\n- Old\n",
+        )
+        .unwrap();
+
+        let entry = read_changelog_entry(dir.path(), "v1.0.0").unwrap();
+        assert!(entry.contains("## Added"));
+        assert!(entry.contains("## Fixed\n- Bug"));
+        assert!(!entry.contains("0.9.0"));
+    }
+
+    #[test]
     fn test_read_unreleased_section_bracketed() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -1251,6 +1266,93 @@ mod tests {
     }
 
     #[test]
+    fn test_split_changelog_ignores_level_two_categories() {
+        let content = "\
+# Changelog
+
+## [Unreleased]
+
+## [3.0.0] - 2025-03-01
+## Added
+- Three
+
+## Fixed
+- Three fix
+
+## [2.0.0] - 2025-02-01
+## Added
+- Two
+
+## [1.0.0] - 2025-01-01
+## Added
+- One
+
+## [0.9.0] - 2024-12-01
+## Fixed
+- Zero nine
+";
+
+        let (head, tail) = split_changelog(content, 3);
+        assert!(head.contains("## Added\n- Three"));
+        assert!(head.contains("## Fixed\n- Three fix"));
+        assert!(head.contains("[1.0.0]"));
+        assert!(!head.contains("[0.9.0]"));
+        assert!(tail.starts_with("## [0.9.0]"));
+    }
+
+    #[test]
+    fn test_split_changelog_ignores_digit_leading_non_versions() {
+        let content = "\
+# Changelog
+
+## [Unreleased]
+
+## [3.0.0]
+- Three
+
+## 2024 Retrospective
+- Not a version
+
+## 1st Quarter Updates
+- Not a version either
+
+## [2.0.0]
+- Two
+
+## [1.0.0]
+- One
+
+## [0.9.0]
+- Zero nine
+";
+
+        let (head, tail) = split_changelog(content, 3);
+        assert!(head.contains("2024 Retrospective"));
+        assert!(head.contains("1st Quarter Updates"));
+        assert!(!head.contains("[0.9.0]"));
+        assert!(tail.starts_with("## [0.9.0]"));
+    }
+
+    #[test]
+    fn test_repair_changelog_section_boundaries() {
+        let content = "- Fix one ([#1](https://github.com/jdx/communique/pull/1))## [1.0.0]\n## Fixed\n- Old ([#0](https://github.com/jdx/communique/pull/0))## [0.9.0]\n";
+
+        let repaired = repair_changelog_section_boundaries(content);
+
+        assert!(repaired.contains("pull/1))\n\n## [1.0.0]"));
+        assert!(repaired.contains("pull/0))\n\n## [0.9.0]"));
+    }
+
+    #[test]
+    fn test_repair_changelog_section_boundaries_ignores_non_versions() {
+        let content = "- Fixed `pattern()## anchor` without changing inline code\n- Also fixed link text)## not a version\n";
+
+        let repaired = repair_changelog_section_boundaries(content);
+
+        assert_eq!(repaired, content);
+    }
+
+    #[test]
     fn test_replace_unreleased_section_bracketed_preserves_tail() {
         let existing = "# Changelog\n\n## [Unreleased]\n\n### Changed\n- Old draft\n\n## [1.0.0] - 2025-01-01\n### Added\n- Old release\n";
         let updated = replace_unreleased_section(existing, "### Added\n- New draft").unwrap();
@@ -1668,6 +1770,72 @@ mod tests {
         // Should preserve the tail (0.9.0)
         assert!(result.contains("[0.9.0]"));
         assert!(result.contains("Zero nine"));
+        assert!(result.contains("- One\n\n## [0.9.0]"));
+    }
+
+    #[tokio::test]
+    async fn test_update_changelog_repairs_existing_joined_boundaries() {
+        let repo = TempRepo::new();
+        repo.write_file(
+            "CHANGELOG.md",
+            "# Changelog\n\n## [Unreleased]\n\n## [1.0.0]\n## Fixed\n- Existing ([#1](https://github.com/jdx/communique/pull/1))## [0.9.0]\n## Fixed\n- Old\n",
+        );
+        repo.commit("initial");
+        repo.tag("v1.0.0");
+        repo.write_file("src/main.rs", "fn main() {}");
+        repo.commit("fix: new fix");
+        repo.tag("v1.1.0");
+
+        let updated_head = "\
+# Changelog
+
+## [Unreleased]
+
+## [1.1.0]
+## Fixed
+- New fix
+
+## [1.0.0]
+## Fixed
+- Existing ([#1](https://github.com/jdx/communique/pull/1))
+
+## [0.9.0]
+## Fixed
+- Old
+";
+
+        let mock_client = MockLlmClient::new(vec![TurnResponse {
+            tool_calls: vec![],
+            text: Some(updated_head.to_string()),
+            stop_reason: StopReason::EndTurn,
+            usage: fake_usage(),
+        }]);
+
+        let ctx = Context {
+            repo_root: repo.path().to_path_buf(),
+            owner_repo: "test/repo".into(),
+            tag: "v1.1.0".into(),
+            prev_tag: "v1.0.0".into(),
+            client: Box::new(mock_client),
+            defaults: Defaults::default(),
+            system_extra: None,
+            context: None,
+            github_client: None,
+        };
+
+        let parsed = ParsedOutput {
+            changelog: "## Fixed\n- New fix".into(),
+            release_title: "v1.1.0".into(),
+            release_body: "Body.".into(),
+            usage: Usage::default(),
+        };
+
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        update_changelog(&ctx, &parsed, false, &job).await.unwrap();
+
+        let result = std::fs::read_to_string(repo.path().join("CHANGELOG.md")).unwrap();
+        assert!(result.contains("pull/1))\n\n## [0.9.0]"));
+        assert!(!result.contains(")## ["));
     }
 
     #[test]
@@ -1684,37 +1852,16 @@ mod tests {
 /// in the head. This limits tokens sent to the LLM for large changelogs.
 fn split_changelog(content: &str, max_versions: usize) -> (&str, &str) {
     let mut version_count = 0;
-    let mut search_start = 0;
 
-    loop {
-        let rest = &content[search_start..];
-        let Some(pos) = rest.find("\n## ") else {
-            break;
-        };
-        let abs_pos = search_start + pos;
-        let header_start = abs_pos + 1; // skip the \n
-
-        // Check if this is [Unreleased] — don't count it
-        let header_line = &content[header_start..];
-        let is_unreleased = header_line.strip_prefix("## ").is_some_and(|s| {
-            s.trim_start().starts_with("[Unreleased]") || s.trim_start().starts_with("Unreleased")
-        });
-
-        if !is_unreleased {
-            version_count += 1;
+    for (start, line) in content.lines_with_offset() {
+        if !is_version_header(line) {
+            continue;
         }
 
-        if version_count >= max_versions {
-            // Find the next ## after this one to split there
-            let after = &content[header_start + 3..];
-            if let Some(next) = after.find("\n## ") {
-                let split_at = header_start + 3 + next + 1; // +1 to include the \n
-                return (&content[..split_at], &content[split_at..]);
-            }
-            break;
+        version_count += 1;
+        if version_count > max_versions {
+            return (&content[..start], &content[start..]);
         }
-
-        search_start = abs_pos + 4; // skip past "\n## "
     }
 
     (content, "")
@@ -1766,16 +1913,121 @@ fn is_forbidden_unreleased_target_header(line: &str) -> bool {
 }
 
 fn is_version_header(line: &str) -> bool {
-    let Some(rest) = line.trim().strip_prefix("## ") else {
-        return false;
-    };
+    header_version(line).is_some()
+}
+
+fn header_version(line: &str) -> Option<&str> {
+    let rest = line.trim().strip_prefix("## ")?;
     let rest = rest.trim_start();
 
-    rest.starts_with('[')
-        || rest.chars().next().is_some_and(|c| c.is_ascii_digit())
-        || rest
-            .strip_prefix('v')
-            .is_some_and(|s| s.chars().next().is_some_and(|c| c.is_ascii_digit()))
+    if let Some(bracketed) = rest.strip_prefix('[') {
+        let (version, _) = bracketed.split_once(']')?;
+        return is_version_like(version).then_some(version);
+    }
+
+    let version = rest
+        .split_once(char::is_whitespace)
+        .map_or(rest, |(version, _)| version);
+    is_version_like(version).then_some(version)
+}
+
+fn is_version_like(value: &str) -> bool {
+    let value = value.strip_prefix('v').unwrap_or(value);
+    value.chars().next().is_some_and(|c| c.is_ascii_digit()) && value.contains('.')
+}
+
+trait LinesWithOffset {
+    fn lines_with_offset(&self) -> LinesWithOffsetIter<'_>;
+}
+
+impl LinesWithOffset for str {
+    fn lines_with_offset(&self) -> LinesWithOffsetIter<'_> {
+        LinesWithOffsetIter {
+            content: self,
+            offset: 0,
+        }
+    }
+}
+
+struct LinesWithOffsetIter<'a> {
+    content: &'a str,
+    offset: usize,
+}
+
+impl<'a> Iterator for LinesWithOffsetIter<'a> {
+    type Item = (usize, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.content.len() {
+            return None;
+        }
+
+        let start = self.offset;
+        let rest = &self.content[start..];
+        let line_len = rest.find('\n').map_or(rest.len(), |idx| idx + 1);
+        self.offset += line_len;
+        Some((start, &self.content[start..start + line_len]))
+    }
+}
+
+fn find_version_section_start(contents: &str, version: &str) -> Option<usize> {
+    let version = version.strip_prefix('v').unwrap_or(version);
+
+    contents
+        .lines_with_offset()
+        .find(|(_, line)| {
+            header_version(line)
+                .map(|header| header.strip_prefix('v').unwrap_or(header) == version)
+                .unwrap_or(false)
+        })
+        .map(|(start, _)| start)
+}
+
+fn find_next_version_section_start(contents: &str, after: usize) -> Option<usize> {
+    contents
+        .lines_with_offset()
+        .find(|(start, line)| *start > after && is_version_header(line))
+        .map(|(start, _)| start)
+}
+
+fn join_changelog_head_tail(head: &str, tail: &str) -> String {
+    let head = head.trim_end();
+    let tail = tail.trim_start_matches(['\r', '\n']);
+
+    if tail.is_empty() {
+        head.to_string()
+    } else if head.is_empty() {
+        tail.to_string()
+    } else {
+        format!("{head}\n\n{tail}")
+    }
+}
+
+fn repair_changelog_section_boundaries(content: &str) -> String {
+    let mut repaired = String::with_capacity(content.len());
+    let mut rest = content;
+
+    while let Some(pos) = rest.find(")## ") {
+        let (before, after_marker) = rest.split_at(pos + 1);
+        repaired.push_str(before);
+        if is_version_header(after_marker.lines().next().unwrap_or("")) {
+            repaired.push_str("\n\n");
+        }
+        rest = after_marker;
+    }
+
+    repaired.push_str(rest);
+    repaired
+}
+
+fn read_changelog_entry(repo_root: &Path, tag: &str) -> Option<String> {
+    let path = repo_root.join("CHANGELOG.md");
+    let contents = xx::file::read_to_string(&path).ok()?;
+
+    let start = find_version_section_start(&contents, tag)?;
+    let end = find_next_version_section_start(&contents, start).unwrap_or(contents.len());
+
+    Some(contents[start..end].trim().to_string())
 }
 
 fn find_unreleased_section(contents: &str) -> miette::Result<Option<ChangelogSection>> {
@@ -1905,6 +2157,7 @@ async fn update_changelog(
     }
 
     let existing = xx::file::read_to_string(&changelog_path)
+        .map(|content| repair_changelog_section_boundaries(&content))
         .unwrap_or_else(|_| "# Changelog\n\n## [Unreleased]\n".to_string());
 
     let (head, tail) = split_changelog(&existing, 3);
@@ -1950,36 +2203,11 @@ Rules:
     );
 
     if !dry_run {
-        let full = if tail.is_empty() {
-            updated_head
-        } else {
-            format!("{updated_head}{tail}")
-        };
+        let full = join_changelog_head_tail(&updated_head, tail);
         let content = format!("{}\n", full.trim_end());
         xx::file::write(&changelog_path, content)?;
         info!("wrote {}", changelog_path.display());
     }
 
     Ok(())
-}
-
-fn read_changelog_entry(repo_root: &Path, tag: &str) -> Option<String> {
-    let path = repo_root.join("CHANGELOG.md");
-    let contents = xx::file::read_to_string(&path).ok()?;
-
-    let version = tag.strip_prefix('v').unwrap_or(tag);
-    let header_pattern = format!("## [{version}]");
-    let alt_pattern = format!("## {version}");
-
-    let start = contents
-        .find(&header_pattern)
-        .or_else(|| contents.find(&alt_pattern))?;
-
-    let rest = &contents[start..];
-    let end = rest[3..]
-        .find("\n## ")
-        .map(|i| start + 3 + i)
-        .unwrap_or(contents.len());
-
-    Some(contents[start..end].trim().to_string())
 }


### PR DESCRIPTION
Fixes the changelog update bug that could join preserved release sections onto the previous bullet, producing lines like `...))## [1.0.4]`.

## Changes

- Treat only version-shaped `##` headings as release boundaries.
- Stop treating `## Added` / `## Fixed` category headings as release sections.
- Join regenerated changelog heads and preserved tails with an explicit blank line.
- Repair existing joined version boundaries before writing a new changelog update.
- Clean up the malformed joins currently present in `CHANGELOG.md`.

## Validation

- `cargo fmt --check`
- `cargo test generate`
- `cargo clippy -- -D warnings`

`cargo clippy --all-targets -- -D warnings` still reports unrelated pre-existing test-target warnings in `src/agent.rs` and `src/providers/mod.rs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes changelog parsing/splitting and write-back behavior, so formatting edge cases could still cause incorrect section detection or misplaced content when updating `CHANGELOG.md`. Scope is limited to release-note generation and includes expanded tests to reduce regressions.
> 
> **Overview**
> Fixes `communique generate --changelog` producing malformed `CHANGELOG.md` where preserved sections could be concatenated onto the prior bullet (e.g. `...))## [1.0.4]`).
> 
> Changelog processing now treats only *version-shaped* `##` headings as release boundaries (ignoring category headings like `## Added`/`## Fixed` and digit-leading non-versions), explicitly joins regenerated head + preserved tail with a blank line, and repairs already-joined boundaries before writing updates. The PR also cleans up existing malformed joins in `CHANGELOG.md` and adds targeted tests covering these edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50e4c5f8b4d8d851d0f9170a9a0e997ca25e467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->