### PR TITLE
ci(release): add musl linux assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,11 @@ jobs:
             os: macos-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest


### PR DESCRIPTION
Add musl Linux binaries to future communique GitHub releases.

## Changes

- Add `x86_64-unknown-linux-musl` to the release matrix.
- Add `aarch64-unknown-linux-musl` to the release matrix.

Future releases should include these additional assets alongside the existing GNU Linux, macOS, and Windows builds:

- `communique-x86_64-unknown-linux-musl.tar.gz`
- `communique-aarch64-unknown-linux-musl.tar.gz`

## Validation

- `actionlint .github/workflows/release.yml`