### PR TITLE
v1.1.2: musl Linux binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/jdx/communique/compare/v1.1.1...v1.1.2) - 2026-04-26
+
+### Fixed
+
+- *(generate)* preserve changelog section boundaries ([#126](https://github.com/jdx/communique/pull/126))
+
+### Other
+
+- *(release)* add musl linux assets ([#127](https://github.com/jdx/communique/pull/127))
+
 ## [1.1.1](https://github.com/jdx/communique/releases/tag/v1.1.1) - 2026-04-26
 
 ## Fixed
@@ -19,16 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
-
-## [1.1.2](https://github.com/jdx/communique/compare/v1.1.1...v1.1.2) - 2026-04-26
-
-### Fixed
-
-- *(generate)* preserve changelog section boundaries ([#126](https://github.com/jdx/communique/pull/126))
-
-### Other
-
-- *(release)* add musl linux assets ([#127](https://github.com/jdx/communique/pull/127))
 
 ## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
 
+## [1.1.2](https://github.com/jdx/communique/compare/v1.1.1...v1.1.2) - 2026-04-26
+
+### Fixed
+
+- *(generate)* preserve changelog section boundaries ([#126](https://github.com/jdx/communique/pull/126))
+
+### Other
+
+- *(release)* add musl linux assets ([#127](https://github.com/jdx/communique/pull/127))
+
 ## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.1.1"
+version "1.1.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.1
+**Version**: 1.1.2
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small patch release that ships musl Linux binaries and stops `communique generate --changelog` from welding release headers onto the bullet above them.

## Added

- **musl Linux binaries** — Releases now include `communique-x86_64-unknown-linux-musl.tar.gz` and `communique-aarch64-unknown-linux-musl.tar.gz` alongside the existing GNU Linux, macOS, and Windows assets, so Alpine and other musl-based distros can run communique without a glibc shim. ([#127](https://github.com/jdx/communique/pull/127)) (@jdx)

## Fixed

- **Preserve changelog section boundaries on `--changelog` updates** — `communique generate <tag> --changelog` could produce malformed `CHANGELOG.md` output where a preserved release header was concatenated onto the prior bullet, e.g. `- ...([#119](…))## [1.0.4] - 2026-04-24`. The changelog splitter now treats only *version-shaped* `## [x.y.z]` / `## vX.Y.Z` headings as release boundaries — `## Added` / `## Fixed` category headers and prose like `## 2024 Retrospective` are no longer mistaken for releases — and the regenerated head and preserved tail are explicitly joined with a blank line. Existing joined boundaries in `CHANGELOG.md` are also repaired in place before the new update is written, and communique's own changelog is cleaned up as part of this release. ([#126](https://github.com/jdx/communique/pull/126)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata/version strings and generated CLI docs, with no functional code changes.
> 
> **Overview**
> Bumps the project version from `1.1.1` to `1.1.2` across `Cargo.toml`, `Cargo.lock`, the usage spec, and generated CLI docs.
> 
> Updates `CHANGELOG.md` with a new `1.1.2` entry noting the changelog-boundary fix and addition of musl Linux release assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4304216601bf063bae74065941bccf7b2212116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->