### PR TITLE
v1.1.2: Deterministic changelog edits & musl Linux builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/jdx/communique/releases/tag/v1.1.2) - 2026-04-26
+
+## Fixed
+
+- *(generate)* Place tagged release entries deterministically in `CHANGELOG.md` instead of letting the LLM rewrite the file ([#129](https://github.com/jdx/communique/pull/129))
+- *(generate)* Preserve section boundaries so preserved release sections no longer get joined onto the previous bullet (e.g. `...))## [1.0.4]`) ([#126](https://github.com/jdx/communique/pull/126))
+
+## Added
+
+- *(release)* Publish `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` archives alongside the existing GNU Linux, macOS, and Windows assets ([#127](https://github.com/jdx/communique/pull/127))
+
 ## [1.1.1](https://github.com/jdx/communique/releases/tag/v1.1.1) - 2026-04-26
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.1.1"
+version "1.1.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.1
+**Version**: 1.1.2
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A patch release that takes the LLM out of the loop when editing `CHANGELOG.md` for tagged releases, fixes a section-boundary bug that could mash release sections together, and adds musl Linux binaries to the release matrix.

## Fixed

- **Place tagged release entries deterministically** — `communique generate vX.Y.Z --changelog` no longer asks the model to rewrite `CHANGELOG.md`. Instead, it parses the existing file, removes any prior section for the target version, and inserts the new section immediately after `## [Unreleased]` / `## Unreleased`. The new `format_version_header` helper infers the existing header style (linked `## [1.1.0](url) - date`, plain `## 1.1.0`, bracketed `## [1.1.0]`, with or without dates) and matches it for the new entry, while the generated changelog body is used verbatim. If the file is missing an Unreleased anchor, the command now fails with an actionable error rather than guessing a placement, and duplicate Unreleased sections are caught even in `--dry-run`. ([#129](https://github.com/jdx/communique/pull/129)) (@jdx)
- **Preserve changelog section boundaries** — Fixed a bug where `--changelog` updates could concatenate a preserved release section onto the previous bullet, producing lines like `...))## [1.0.4]`. Only version-shaped `##` headings are now treated as release boundaries (category headings like `## Added` / `## Fixed` are no longer mistaken for them), regenerated heads and preserved tails are joined with an explicit blank line, and any pre-existing joined boundaries are repaired before writing. The malformed joins already present in this repo's own `CHANGELOG.md` were also cleaned up. ([#126](https://github.com/jdx/communique/pull/126)) (@jdx)

## Added

- **musl Linux release assets** — Future GitHub releases now include `communique-x86_64-unknown-linux-musl.tar.gz` and `communique-aarch64-unknown-linux-musl.tar.gz` alongside the existing GNU Linux, macOS, and Windows builds. ([#127](https://github.com/jdx/communique/pull/127)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (changelog, crate/package versions, and generated CLI docs) with no functional code changes.
> 
> **Overview**
> Adds a new `v1.1.2` entry to `CHANGELOG.md` describing fixes to deterministic `--changelog` updates and section-boundary preservation, plus added musl Linux release artifacts.
> 
> Bumps the project version from `1.1.1` → `1.1.2` in `Cargo.toml`/`Cargo.lock`, the usage spec (`communique.usage.kdl`), and generated CLI documentation (`docs/cli`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c3f940d4e94a0e296e574eca305a018d40e3d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->