### PR TITLE
docs: rewrite readme for end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,196 @@
-# communiqué
+# communique
 
-Editorialized release notes powered by AI.
+AI-generated release notes for people who read release notes.
 
-communiqué is a CLI tool that uses an AI agent to generate professional, narrative release notes from your git history, PRs, and source code. Currently powered by Claude.
+communique turns your git history, pull requests, and repository context into
+polished release notes. It can print notes locally, update `CHANGELOG.md`, or
+publish directly to a GitHub Release.
 
 ## Install
+
+Install with [mise](https://mise.jdx.dev):
+
+```sh
+mise use communique
+```
+
+Or install with Cargo:
 
 ```sh
 cargo install communique
 ```
 
-## Quick Start
+Pre-built binaries for macOS, Linux, and Windows are available on the
+[GitHub releases page](https://github.com/jdx/communique/releases).
+
+## Setup
+
+communique needs an LLM API key. Claude models use Anthropic; other models use
+the OpenAI-compatible provider path.
 
 ```sh
+# Default Claude models
 export ANTHROPIC_API_KEY="sk-ant-..."
-export GITHUB_TOKEN="ghp_..."       # optional, for PR context and publishing
 
-communique init                      # create communique.toml
-communique generate v1.0.0           # generate release notes
-communique generate v1.0.0 --github-release  # generate and publish
+# OpenAI-compatible models
+export OPENAI_API_KEY="sk-..."
 ```
 
-## Roadmap
+GitHub context and GitHub Release publishing also need a token:
 
-### Features
+```sh
+export GITHUB_TOKEN="$(gh auth token)"
+```
 
-- [ ] Multi-provider LLM support (abstract behind a trait, add OpenAI/etc.)
-- [ ] Dry-run mode — preview before publishing to GitHub
-- [x] Progress indication (spinner/status while fetching PRs and waiting on LLM)
-- [ ] Output to file (`--output <path>`)
-- [ ] `--verbose`/`--quiet` flags instead of requiring `RUST_LOG`
-- [ ] Non-GitHub forge support (GitLab, Gitea)
-- [ ] Parallel PR fetching (tokio is already a dependency)
-- [ ] Retry with exponential backoff on API calls (Anthropic and GitHub)
-- [ ] Validate git tag exists before proceeding
-- [ ] Batch mode — generate notes for multiple tags in one run
+Initialize a config file in your repository:
 
-### Code Quality
+```sh
+communique init
+```
 
-- [ ] Replace `.unwrap()`/`.expect()` with proper error returns (`anthropic.rs`, `git.rs`, `main.rs`)
-- [ ] Make output parsing more resilient — fallback if `---SECTION_BREAK---` is missing
-- [ ] Use `LazyLock` for compiled regex in `git.rs:extract_pr_numbers()`
-- [ ] Avoid cloning full message history every agent loop iteration
-- [ ] Update `anthropic-version` header (currently pinned to `2023-06-01`)
-- [ ] Config validation (e.g. `max_tokens > 0`)
+This creates `communique.toml`, where you can set the default model, repository,
+style instructions, and project context.
 
-### Testing
+## Generate Release Notes
 
-- [ ] Unit tests for output parsing (`output::parse()`)
-- [ ] Unit tests for config loading and validation
-- [ ] Unit tests for all tools (`read_file`, `list_files`, `grep`, `get_pr`, `get_pr_diff`)
-- [ ] Unit tests for changelog entry reading
-- [ ] Integration tests with mocked API responses
-- [ ] CI test workflow
+Generate notes for a tag:
+
+```sh
+communique generate v1.2.0
+```
+
+communique automatically detects the previous tag. You can provide it explicitly
+when needed:
+
+```sh
+communique generate v1.2.0 v1.1.0
+```
+
+Preview without publishing or verifying links:
+
+```sh
+communique generate v1.2.0 --dry-run
+```
+
+Write the output to a file:
+
+```sh
+communique generate v1.2.0 --output RELEASE_NOTES.md
+```
+
+## Update GitHub Releases
+
+Publish generated notes to an existing GitHub Release:
+
+```sh
+communique generate v1.2.0 --github-release
+```
+
+communique reads commits and pull requests, lets the model inspect relevant
+files and diffs, verifies links, then replaces the GitHub Release body with the
+finished notes.
+
+## Update CHANGELOG.md
+
+Add or replace the version entry in `CHANGELOG.md`:
+
+```sh
+communique generate v1.2.0 --changelog
+```
+
+For release PRs, this keeps the `[Unreleased]` section in place and inserts the
+new version entry immediately below it.
+
+Use concise changelog output when you do not want a full release narrative:
+
+```sh
+communique generate v1.2.0 --changelog --concise
+```
+
+## Configuration
+
+`communique.toml` supports project-level defaults and writing guidance:
+
+```toml
+context = """
+This is a Rust CLI used by platform engineers.
+Call out breaking changes and migration steps clearly.
+"""
+
+system_extra = """
+Write in a direct, practical tone.
+Avoid marketing language.
+"""
+
+[defaults]
+model = "claude-opus-4-7"
+repo = "owner/repo"
+max_tokens = 4096
+```
+
+CLI flags override config defaults.
+
+## GitHub Actions
+
+Use `fetch-depth: 0` so communique can compare tags:
+
+```yaml
+name: Release Notes
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+permissions:
+  contents: write
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - run: cargo install communique
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: communique generate "${{ github.ref_name }}" --github-release
+```
+
+See the [GitHub Actions guide](docs/guide/github-actions.md) for release-plz
+examples and release PR workflows.
+
+## Common Options
+
+```sh
+communique generate v1.2.0 --repo owner/repo
+communique generate v1.2.0 --model claude-opus-4-7
+communique generate v1.2.0 --provider openai --base-url https://api.example.com/v1
+communique generate v1.2.0 --quiet
+communique generate v1.2.0 --verbose
+```
+
+## Troubleshooting
+
+If PR details are missing, confirm `GITHUB_TOKEN` is set and can read the
+repository.
+
+If generation fails because tags cannot be compared, fetch full history and
+tags:
+
+```sh
+git fetch --tags --unshallow
+```
+
+If `CHANGELOG.md` updates fail, make sure the file has an `## [Unreleased]` or
+`## Unreleased` section.
+
+## Documentation
+
+- [Getting started](docs/guide/getting-started.md)
+- [Configuration](docs/guide/configuration.md)
+- [GitHub Actions](docs/guide/github-actions.md)
+- [CLI reference](docs/cli/index.md)

--- a/README.md
+++ b/README.md
@@ -101,10 +101,16 @@ communique generate v1.2.0 --changelog
 For release PRs, this keeps the `[Unreleased]` section in place and inserts the
 new version entry immediately below it.
 
-Use concise changelog output when you do not want a full release narrative:
+Use concise output when you do not want a full release narrative:
 
 ```sh
-communique generate v1.2.0 --changelog --concise
+communique generate v1.2.0 --concise
+```
+
+You can combine concise output with changelog updates:
+
+```sh
+communique generate v1.2.0 --concise --changelog
 ```
 
 ## Configuration
@@ -152,7 +158,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: cargo install communique
+      - uses: jdx/mise-action@v3
+      - run: mise use communique
       - name: Generate release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- replace the internal roadmap-style README with end-user installation, setup, and usage docs
- cover GitHub Release publishing, CHANGELOG.md updates, config, CI, and troubleshooting
- link to the deeper docs guides for details

## Validation
- not run; documentation-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that rewrites `README.md` to be end-user focused; no code paths or runtime behavior are affected.
> 
> **Overview**
> Replaces the roadmap-style `README.md` with end-user documentation covering installation (mise/Cargo/binaries), required API tokens, and step-by-step usage for generating notes, updating `CHANGELOG.md`, and publishing to GitHub Releases.
> 
> Adds examples for configuration (`communique.toml`), GitHub Actions CI usage, common CLI options, troubleshooting tips, and links to deeper guides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879398d67bbfdeb9142387a09cc5f416c1f09517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->