### PR TITLE
v1.1.3: Lock down read_file to tracked paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/jdx/communique/releases/tag/v1.1.3) - 2026-05-06
+
+## Fixed
+
+- Restrict the `read_file` tool to git-tracked paths, blocking reads of `.env`, gitignored secrets, build artifacts, and `.git/` internals ([#133](https://github.com/jdx/communique/pull/133))
+- Send `max_completion_tokens` instead of `max_tokens` for OpenAI GPT-5+ and o-series reasoning models, which reject the older parameter ([#148](https://github.com/jdx/communique/pull/148))
+
+## Changed
+
+- Rewrite the README as end-user documentation covering installation, configuration, CHANGELOG/Release publishing, and CI usage ([#131](https://github.com/jdx/communique/pull/131))
+
 ## [1.1.2](https://github.com/jdx/communique/releases/tag/v1.1.2) - 2026-04-26
 
 ## Fixed
 
 - *(generate)* Place tagged release entries deterministically in `CHANGELOG.md` instead of letting the LLM rewrite the file ([#129](https://github.com/jdx/communique/pull/129))
-- *(generate)* Preserve section boundaries so preserved release sections no longer get joined onto the previous bullet (e.g. `...))## [1.0.4]`) ([#126](https://github.com/jdx/communique/pull/126))
+- *(generate)* Preserve section boundaries so preserved release sections no longer get joined onto the previous bullet (e.g. `...))
+
+## [1.0.4]`) ([#126](https://github.com/jdx/communique/pull/126))
 
 ## Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.1.2"
+version "1.1.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -316,7 +316,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.2
+**Version**: 1.1.3
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A patch release that tightens the `read_file` tool's sandbox so it can only read git-tracked files, and fixes OpenAI request payloads for GPT-5 and o-series models.

## Fixed

- **`read_file` is now restricted to git-tracked paths** — Previously the tool only guarded against `..` traversal, which meant anything else inside the working tree (including gitignored files like `.env`, build artifacts, and `.git/` internals) was readable. The tool now runs `git ls-files --error-unmatch` on the requested path and rejects anything untracked or gitignored, while keeping the canonicalize check as defense-in-depth against tracked symlinks that resolve outside the repo. This matches how `list_files` and `grep` already behave. ([#133](https://github.com/jdx/communique/pull/133)) (@jdx)
- **OpenAI `max_completion_tokens` for newer models** — GPT-5+ and OpenAI o-series reasoning models (`o1`, `o3`, `o4-mini`, …) reject the legacy `max_tokens` field. The OpenAI provider now detects these model names (including `provider/model` forms like `openai/gpt-5.1`) and sends `max_completion_tokens` instead, while continuing to send `max_tokens` for GPT-4 and arbitrary OpenAI-compatible endpoints. ([#148](https://github.com/jdx/communique/pull/148)) (@jdx)

## Changed

- **README rewritten for end users** — Replaces the previous roadmap-style README with installation instructions (mise, Cargo, prebuilt binaries), required API tokens, step-by-step usage for generating notes and updating `CHANGELOG.md`, a `communique.toml` example, GitHub Actions snippets, and troubleshooting tips. ([#131](https://github.com/jdx/communique/pull/131)) (@jdx)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only: version bumps and documentation/changelog updates, with no functional code changes in the diff.
> 
> **Overview**
> Prepares the `v1.1.3` release by bumping the crate/CLI version from `1.1.2` → `1.1.3` across `Cargo.toml`, `Cargo.lock`, the usage spec, and generated CLI docs.
> 
> Adds a new `CHANGELOG.md` entry for `1.1.3` documenting the release’s fixes/changes (including `read_file` path restrictions and an OpenAI token parameter update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7db80d8c35f15c1063eac30520f52bc25ae3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->