### PR TITLE
fix(read_file): restrict to git-tracked paths

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -2,7 +2,7 @@ pub fn system_prompt(extra: Option<&str>, emoji: bool) -> String {
     let mut prompt = r#"You are an expert technical writer generating release notes for a software project.
 
 You have access to tools to browse the repository:
-- read_file: Read file contents (path relative to repo root)
+- read_file: Read contents of a git-tracked file (path relative to repo root)
 - list_files: List tracked files, optionally filtered by glob
 - grep: Search file contents with ripgrep
 - get_pr: Fetch GitHub PR details (title, body, labels, author)

--- a/src/tools/read_file.rs
+++ b/src/tools/read_file.rs
@@ -119,8 +119,6 @@ mod tests {
 
     #[test]
     fn test_read_file_path_traversal() {
-        let outer = tempfile::tempdir().unwrap();
-        std::fs::write(outer.path().join("secret.txt"), "sensitive").unwrap();
         let repo = TempRepo::new();
         repo.write_file("README.md", "# hi");
         repo.commit("init");
@@ -130,8 +128,28 @@ mod tests {
             err.to_string().contains("not a git-tracked file"),
             "unexpected error: {err}"
         );
-        // keep `outer` alive until the assertion runs
-        drop(outer);
+    }
+
+    // Defense-in-depth: even when git tracks the path, a symlink resolving
+    // outside the repo must be rejected by the canonicalize check.
+    #[cfg(unix)]
+    #[test]
+    fn test_read_file_tracked_symlink_outside_repo_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, "sensitive").unwrap();
+
+        let repo = TempRepo::new();
+        symlink(&secret, repo.path().join("link")).unwrap();
+        repo.commit("add symlink");
+
+        let err = execute(repo.path(), &json!({"path": "link"})).unwrap_err();
+        assert!(
+            err.to_string().contains("escapes repo root"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/src/tools/read_file.rs
+++ b/src/tools/read_file.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::Command;
 
 use serde_json::json;
 
@@ -9,14 +10,14 @@ pub fn definition() -> ToolDefinition {
     ToolDefinition {
         name: "read_file".into(),
         description:
-            "Read the contents of a file in the repository. Path is relative to the repo root."
+            "Read the contents of a git-tracked file in the repository. Path is relative to the repo root."
                 .into(),
         input_schema: json!({
             "type": "object",
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "File path relative to repo root"
+                    "description": "File path relative to repo root (must be tracked by git)"
                 }
             },
             "required": ["path"]
@@ -29,12 +30,25 @@ pub fn execute(repo_root: &Path, input: &serde_json::Value) -> Result<String> {
         .as_str()
         .ok_or_else(|| Error::Tool("read_file: missing 'path' parameter".into()))?;
 
+    // Sandbox: only permit reading files tracked by git. This excludes secrets
+    // like .env, gitignored build artifacts, and .git internals.
+    let tracked = Command::new("git")
+        .args(["ls-files", "--error-unmatch", "--", rel_path])
+        .current_dir(repo_root)
+        .output()
+        .map_err(|e| Error::Tool(format!("read_file: git ls-files: {e}")))?;
+    if !tracked.status.success() {
+        return Err(Error::Tool(format!(
+            "read_file: {rel_path}: not a git-tracked file"
+        )));
+    }
+
     let full_path = repo_root.join(rel_path);
     let canonical = full_path
         .canonicalize()
         .map_err(|e| Error::Tool(format!("read_file: {rel_path}: {e}")))?;
 
-    // Sandbox: ensure resolved path is within repo root
+    // Defense in depth: a tracked symlink could resolve outside the repo.
     let root_canonical = repo_root
         .canonicalize()
         .map_err(|e| Error::Tool(format!("read_file: cannot resolve repo root: {e}")))?;
@@ -61,40 +75,80 @@ pub fn execute(repo_root: &Path, input: &serde_json::Value) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_helpers::TempRepo;
     use serde_json::json;
 
     #[test]
-    fn test_read_file_normal() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("hello.txt"), "world").unwrap();
-        let result = execute(dir.path(), &json!({"path": "hello.txt"})).unwrap();
+    fn test_read_file_tracked() {
+        let repo = TempRepo::new();
+        repo.write_file("hello.txt", "world");
+        repo.commit("init");
+
+        let result = execute(repo.path(), &json!({"path": "hello.txt"})).unwrap();
         assert_eq!(result, "world");
+    }
+
+    #[test]
+    fn test_read_file_untracked_rejected() {
+        let repo = TempRepo::new();
+        repo.write_file("README.md", "# hi");
+        repo.commit("init");
+        // .env exists on disk but is not tracked
+        repo.write_file(".env", "SECRET=hunter2");
+
+        let err = execute(repo.path(), &json!({"path": ".env"})).unwrap_err();
+        assert!(
+            err.to_string().contains("not a git-tracked file"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_read_file_gitignored_rejected() {
+        let repo = TempRepo::new();
+        repo.write_file(".gitignore", "secrets.txt\n");
+        repo.commit("init");
+        repo.write_file("secrets.txt", "API_KEY=abc");
+
+        let err = execute(repo.path(), &json!({"path": "secrets.txt"})).unwrap_err();
+        assert!(
+            err.to_string().contains("not a git-tracked file"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn test_read_file_path_traversal() {
         let outer = tempfile::tempdir().unwrap();
-        let inner = outer.path().join("repo");
-        std::fs::create_dir(&inner).unwrap();
         std::fs::write(outer.path().join("secret.txt"), "sensitive").unwrap();
+        let repo = TempRepo::new();
+        repo.write_file("README.md", "# hi");
+        repo.commit("init");
 
-        let err = execute(&inner, &json!({"path": "../secret.txt"})).unwrap_err();
-        assert!(err.to_string().contains("escapes repo root"));
+        let err = execute(repo.path(), &json!({"path": "../secret.txt"})).unwrap_err();
+        assert!(
+            err.to_string().contains("not a git-tracked file"),
+            "unexpected error: {err}"
+        );
+        // keep `outer` alive until the assertion runs
+        drop(outer);
     }
 
     #[test]
     fn test_read_file_truncation() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("big.txt"), "x".repeat(200_000)).unwrap();
-        let result = execute(dir.path(), &json!({"path": "big.txt"})).unwrap();
+        let repo = TempRepo::new();
+        repo.write_file("big.txt", &"x".repeat(200_000));
+        repo.commit("init");
+
+        let result = execute(repo.path(), &json!({"path": "big.txt"})).unwrap();
         assert!(result.contains("[file truncated at 100KB]"));
         assert!(result.len() < 200_000);
     }
 
     #[test]
     fn test_read_file_missing_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let err = execute(dir.path(), &json!({})).unwrap_err();
+        let repo = TempRepo::new();
+        let err = execute(repo.path(), &json!({})).unwrap_err();
         assert!(err.to_string().contains("missing 'path'"));
     }
 }


### PR DESCRIPTION
## Summary
- The `read_file` tool sandboxed against `..` traversal, but anything else inside the working tree was fair game — including gitignored secrets like `.env`. Tighten the sandbox to require the path be tracked by git (`git ls-files --error-unmatch`), which excludes `.env`, build artifacts, and `.git/` internals automatically.
- Aligns with the existing tools: `list_files` already uses `git ls-files`, and `grep` (rg) honors `.gitignore`.
- Defense-in-depth canonicalize check is retained in case a tracked symlink resolves outside the repo.

## Test plan
- [x] `cargo test tools::read_file` — new coverage for `.env`, gitignored, and traversal cases
- [x] `cargo test` — full suite green (164 unit + 3 integration)
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `read_file` behavior to reject any untracked/gitignored paths by shelling out to `git ls-files`, which could break callers that relied on reading working-tree files and adds a runtime dependency on git being available.
> 
> **Overview**
> Tightens the `read_file` tool sandbox to **only allow reading git-tracked files**, rejecting untracked, gitignored, and traversal paths via a `git ls-files --error-unmatch` check, while keeping the canonical-path guard to block symlinks that escape the repo.
> 
> Updates the tool/prompt descriptions accordingly and expands tests to cover tracked reads, `.env`/gitignored rejection, traversal rejection, and (unix-only) tracked symlink escape detection using `TempRepo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6740fa8a2b74c17677c98b8b235f737699338da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->