### PR TITLE
Use GitHub token for private link verification

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -199,7 +199,13 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         if let Some((tool_call_id, parsed)) = submit {
             if verify_links {
                 job.prop("message", "Verifying links...");
-                let broken = links::verify(&[&parsed.changelog, &parsed.release_body]).await;
+                let texts = [parsed.changelog.as_str(), parsed.release_body.as_str()];
+                let broken = if let Some(gh) = github {
+                    let link_options = links::VerifyOptions::new(Some(gh.token()), gh.base_url());
+                    links::verify_with_options(&texts, &link_options).await
+                } else {
+                    links::verify(&texts).await
+                };
                 if !broken.is_empty() {
                     let summary = broken
                         .iter()
@@ -907,6 +913,59 @@ mod tests {
         let result = run(ctx).await.unwrap();
         assert_eq!(result.changelog, "changes");
         assert_eq!(result.release_body, format!("See {url}"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_links_uses_github_token_for_browser_links() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/repos/owner/repo/pulls/123"))
+            .and(wiremock::matchers::header(
+                "Authorization",
+                "Bearer test-token",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let gh = crate::github::GitHubClient::with_base_url(
+            "test-token".into(),
+            "owner/repo",
+            server.uri(),
+        )
+        .unwrap();
+        let client = MockLlmClient::new(vec![TurnResponse {
+            tool_calls: vec![ToolCall {
+                id: "call_1".into(),
+                name: "submit_release_notes".into(),
+                input: json!({
+                    "changelog": "changes",
+                    "release_title": "v1.0",
+                    "release_body": "See https://github.com/owner/repo/pull/123",
+                }),
+            }],
+            text: None,
+            stop_reason: StopReason::ToolUse,
+            usage: fake_usage(),
+        }]);
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        let tmp = std::env::temp_dir();
+        let ctx = AgentContext {
+            client: &client,
+            system: "",
+            user_message: "",
+            tool_defs: vec![],
+            repo_root: &tmp,
+            github: Some(&gh),
+            verify_links: true,
+            job: &job,
+        };
+        let result = run(ctx).await.unwrap();
+        assert_eq!(
+            result.release_body,
+            "See https://github.com/owner/repo/pull/123"
+        );
     }
 
     #[tokio::test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -63,9 +63,25 @@ impl GitHubClient {
     }
 
     pub(crate) fn with_base_url(token: String, owner_repo: &str, base_url: String) -> Result<Self> {
+        if token.is_empty() {
+            return Err(Error::GitHub("GITHUB_TOKEN cannot be empty".into()));
+        }
         let (owner, repo) = owner_repo
             .split_once('/')
             .ok_or_else(|| Error::GitHub(format!("invalid owner/repo: {owner_repo}")))?;
+        let base_url = base_url.trim_end_matches('/').to_string();
+        let parsed_base_url = reqwest::Url::parse(&base_url)
+            .map_err(|e| Error::GitHub(format!("invalid GitHub API base URL: {e}")))?;
+        if parsed_base_url.host_str().is_none() {
+            return Err(Error::GitHub(
+                "GitHub API base URL must include a host".into(),
+            ));
+        }
+        if parsed_base_url.query().is_some() || parsed_base_url.fragment().is_some() {
+            return Err(Error::GitHub(
+                "GitHub API base URL cannot include a query or fragment".into(),
+            ));
+        }
         let client = reqwest::Client::builder()
             .user_agent("communique/0.1")
             .build()?;
@@ -76,6 +92,15 @@ impl GitHubClient {
             repo: repo.to_string(),
             base_url,
         })
+    }
+
+    pub(crate) fn token(&self) -> &str {
+        debug_assert!(!self.token.is_empty());
+        &self.token
+    }
+
+    pub(crate) fn base_url(&self) -> reqwest::Url {
+        reqwest::Url::parse(&self.base_url).expect("GitHubClient base URL must be valid")
     }
 
     fn api_url(&self, path: &str) -> String {
@@ -248,6 +273,50 @@ mod tests {
                 .unwrap()
                 .to_string()
                 .contains("invalid owner/repo")
+        );
+    }
+
+    #[test]
+    fn test_new_empty_token() {
+        let result = GitHubClient::new("".into(), "owner/repo");
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_missing_host() {
+        let result =
+            GitHubClient::with_base_url("token".into(), "owner/repo", "file:///tmp".into());
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("must include a host")
+        );
+    }
+
+    #[test]
+    fn test_with_base_url_rejects_query_or_fragment() {
+        let result = GitHubClient::with_base_url(
+            "token".into(),
+            "owner/repo",
+            "https://api.github.com?x=1".into(),
+        );
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("query or fragment")
         );
     }
 

--- a/src/links.rs
+++ b/src/links.rs
@@ -1,5 +1,39 @@
 use log::warn;
 use regex::Regex;
+use reqwest::{StatusCode, Url};
+
+const DEFAULT_GITHUB_API_BASE_URL: &str = "https://api.github.com";
+
+pub(crate) struct VerifyOptions<'a> {
+    github_token: Option<&'a str>,
+    github_api_base_url: Url,
+}
+
+impl<'a> Default for VerifyOptions<'a> {
+    fn default() -> Self {
+        Self {
+            github_token: None,
+            github_api_base_url: Url::parse(DEFAULT_GITHUB_API_BASE_URL)
+                .expect("default GitHub API base URL must be valid"),
+        }
+    }
+}
+
+impl<'a> VerifyOptions<'a> {
+    pub(crate) fn new(github_token: Option<&'a str>, mut github_api_base_url: Url) -> Self {
+        assert!(
+            github_api_base_url.host_str().is_some(),
+            "GitHub API base URL must include a host"
+        );
+        // Query strings and fragments are not meaningful for an API base URL.
+        github_api_base_url.set_query(None);
+        github_api_base_url.set_fragment(None);
+        Self {
+            github_token,
+            github_api_base_url,
+        }
+    }
+}
 
 /// Extract all markdown links and bare URLs from text.
 fn extract_urls(text: &str) -> Vec<String> {
@@ -11,9 +45,24 @@ fn extract_urls(text: &str) -> Vec<String> {
         .collect()
 }
 
-/// Verify all URLs in the given texts return non-404 responses.
-/// Returns a list of broken URLs.
+/// Verify URLs in the given texts and report inaccessible links.
+///
+/// Generic URLs preserve the historical behavior of only reporting `404` responses
+/// and network errors. Exact GitHub URLs may also report `401`/`403` responses so
+/// private or unauthorized links can be surfaced with more actionable diagnostics.
 pub async fn verify(texts: &[&str]) -> Vec<(String, String)> {
+    verify_with_options(texts, &VerifyOptions::default()).await
+}
+
+/// Verify all URLs in the given texts with optional GitHub API authentication.
+///
+/// GitHub bearer auth is only sent to exact GitHub API URLs or to the configured
+/// GitHub API base URL after recognized `github.com/{owner}/{repo}/...` browser
+/// URLs are translated to API endpoints.
+pub(crate) async fn verify_with_options(
+    texts: &[&str],
+    options: &VerifyOptions<'_>,
+) -> Vec<(String, String)> {
     let mut all_urls = Vec::new();
     for text in texts {
         all_urls.extend(extract_urls(text));
@@ -23,47 +72,280 @@ pub async fn verify(texts: &[&str]) -> Vec<(String, String)> {
         return Vec::new();
     }
 
-    let client = reqwest::Client::builder()
+    let generic_client = reqwest::Client::builder()
         .user_agent("communique/0.1 link-checker")
         .timeout(std::time::Duration::from_secs(10))
         .redirect(reqwest::redirect::Policy::limited(5))
         .build()
         .unwrap();
+    let github_api_client = reqwest::Client::builder()
+        .user_agent("communique/0.1 link-checker")
+        .timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
 
+    let github_token = options.github_token.filter(|token| !token.is_empty());
     let mut broken = Vec::new();
     for url in &all_urls {
-        match client.head(url).send().await {
-            Ok(resp) if resp.status() == 404 => {
-                warn!("broken link: {url} (404)");
-                broken.push((url.clone(), "404".into()));
+        let parsed = Url::parse(url).ok();
+        let github_api_request = github_token.and_then(|token| {
+            parsed
+                .as_ref()
+                .and_then(|parsed_url| {
+                    github_api_path_for(parsed_url, &options.github_api_base_url)
+                })
+                .map(|api_path| (token, api_path))
+        });
+        if let Some((token, api_path)) = github_api_request {
+            if let Some(reason) = verify_github_api(
+                &github_api_client,
+                token,
+                &options.github_api_base_url,
+                &api_path,
+            )
+            .await
+            {
+                warn!("broken link: {url} ({reason})");
+                broken.push((url.clone(), reason));
             }
-            Ok(resp) if resp.status() == 405 => {
-                // HEAD not allowed, try GET
-                match client.get(url).send().await {
-                    Ok(resp) if resp.status() == 404 => {
-                        warn!("broken link: {url} (404)");
-                        broken.push((url.clone(), "404".into()));
-                    }
-                    Err(e) => {
-                        warn!("broken link: {url} ({e})");
-                        broken.push((url.clone(), e.to_string()));
-                    }
-                    _ => {}
-                }
-            }
-            Err(e) => {
-                warn!("broken link: {url} ({e})");
-                broken.push((url.clone(), e.to_string()));
-            }
-            _ => {}
+            continue;
+        }
+
+        let is_github_url = parsed.as_ref().is_some_and(is_exact_github_url);
+        if let Some(reason) =
+            verify_generic(&generic_client, url, is_github_url, github_token.is_some()).await
+        {
+            warn!("broken link: {url} ({reason})");
+            broken.push((url.clone(), reason));
         }
     }
     broken
 }
 
+async fn verify_generic(
+    client: &reqwest::Client,
+    url: &str,
+    is_github_url: bool,
+    github_token_available: bool,
+) -> Option<String> {
+    match client.head(url).send().await {
+        Ok(resp) if should_report_status(resp.status(), is_github_url) => Some(status_reason(
+            resp.status(),
+            is_github_url,
+            github_token_available,
+        )),
+        Ok(resp) if resp.status() == StatusCode::METHOD_NOT_ALLOWED => {
+            // HEAD not allowed, try GET
+            match client.get(url).send().await {
+                Ok(resp) if should_report_status(resp.status(), is_github_url) => Some(
+                    status_reason(resp.status(), is_github_url, github_token_available),
+                ),
+                Err(e) => Some(e.to_string()),
+                _ => None,
+            }
+        }
+        Err(e) => Some(e.to_string()),
+        _ => None,
+    }
+}
+
+async fn verify_github_api(
+    client: &reqwest::Client,
+    token: &str,
+    api_base_url: &Url,
+    api_path: &str,
+) -> Option<String> {
+    debug_assert!(!token.is_empty());
+    let api_url = match append_api_path(api_base_url, api_path) {
+        Ok(url) => url,
+        Err(reason) => return Some(reason),
+    };
+    match client
+        .get(api_url)
+        .bearer_auth(token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => None,
+        Ok(resp) => Some(github_api_status_reason(resp.status())),
+        Err(e) => Some(e.to_string()),
+    }
+}
+
+fn append_api_path(api_base_url: &Url, api_path: &str) -> Result<Url, String> {
+    debug_assert!(api_path.starts_with('/'));
+    let base = api_base_url.as_str().trim_end_matches('/');
+    Url::parse(&format!("{base}{api_path}"))
+        .map_err(|e| format!("invalid GitHub API URL for {api_path}: {e}"))
+}
+
+fn should_report_status(status: StatusCode, is_github_url: bool) -> bool {
+    status == StatusCode::NOT_FOUND
+        || (is_github_url && matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN))
+}
+
+fn status_reason(status: StatusCode, is_github_url: bool, github_token_available: bool) -> String {
+    if is_github_url {
+        github_browser_status_reason(status, github_token_available)
+    } else {
+        status.as_u16().to_string()
+    }
+}
+
+fn github_browser_status_reason(status: StatusCode, github_token_available: bool) -> String {
+    let code = status.as_u16();
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::NOT_FOUND
+            if github_token_available =>
+        {
+            format!(
+                "{code} (GitHub link shape is not API-verifiable; checked without authentication)"
+            )
+        }
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::NOT_FOUND => format!(
+            "{code} (GitHub link is inaccessible or unverified; it may require GITHUB_TOKEN access)"
+        ),
+        _ => code.to_string(),
+    }
+}
+
+fn github_api_status_reason(status: StatusCode) -> String {
+    let code = status.as_u16();
+    match status {
+        StatusCode::UNAUTHORIZED => format!("{code} (GitHub token was rejected)"),
+        StatusCode::FORBIDDEN => {
+            format!("{code} (GitHub token may not have sufficient permissions)")
+        }
+        StatusCode::NOT_FOUND => format!("{code} (GitHub link not found or token lacks access)"),
+        _ => code.to_string(),
+    }
+}
+
+fn is_exact_github_url(url: &Url) -> bool {
+    is_exact_https_host(url, "github.com") || is_exact_https_host(url, "api.github.com")
+}
+
+fn is_exact_https_host(url: &Url, host: &str) -> bool {
+    url.scheme() == "https" && url.host_str() == Some(host)
+}
+
+fn github_api_path_for(url: &Url, api_base_url: &Url) -> Option<String> {
+    if is_exact_https_host(url, "github.com") {
+        return browser_url_to_api_path(url);
+    }
+    if is_exact_https_host(url, "api.github.com") {
+        return Some(url.path().to_string());
+    }
+    if is_under_configured_api_base(url, api_base_url) {
+        return configured_api_path(url, api_base_url);
+    }
+    None
+}
+
+fn browser_url_to_api_path(url: &Url) -> Option<String> {
+    debug_assert!(is_exact_https_host(url, "github.com"));
+    let segments: Vec<_> = url
+        .path()
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.len() < 2 {
+        return None;
+    }
+
+    let owner = segments[0];
+    let repo = segments[1];
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+
+    match segments.get(2).copied() {
+        None => Some(repo_api_path(owner, repo, "")),
+        Some("pull") if segments.len() == 4 => {
+            let number = issue_number(segments[3])?;
+            Some(repo_api_path(owner, repo, &format!("/pulls/{number}")))
+        }
+        Some("issues") if segments.len() == 4 => {
+            let number = issue_number(segments[3])?;
+            Some(repo_api_path(owner, repo, &format!("/issues/{number}")))
+        }
+        Some("commit") if segments.len() == 4 => Some(repo_api_path(
+            owner,
+            repo,
+            &format!("/commits/{}", segments[3]),
+        )),
+        Some("commits") if segments.len() == 4 => Some(repo_api_path(
+            owner,
+            repo,
+            &format!("/commits/{}", segments[3]),
+        )),
+        Some("releases") => release_api_path(owner, repo, &segments),
+        Some("compare") if segments.len() >= 4 => {
+            let compare = segments[3..].join("/");
+            Some(repo_api_path(owner, repo, &format!("/compare/{compare}")))
+        }
+        _ => None,
+    }
+}
+
+fn release_api_path(owner: &str, repo: &str, segments: &[&str]) -> Option<String> {
+    match segments.get(3).copied() {
+        None if segments.len() == 3 => Some(repo_api_path(owner, repo, "/releases")),
+        Some("tag") if segments.len() >= 5 => {
+            let tag = segments[4..].join("/");
+            Some(repo_api_path(owner, repo, &format!("/releases/tags/{tag}")))
+        }
+        Some("latest") if segments.len() == 4 => {
+            Some(repo_api_path(owner, repo, "/releases/latest"))
+        }
+        _ => None,
+    }
+}
+
+fn issue_number(segment: &str) -> Option<u64> {
+    segment.parse::<u64>().ok().filter(|number| *number > 0)
+}
+
+fn repo_api_path(owner: &str, repo: &str, suffix: &str) -> String {
+    format!("/repos/{owner}/{repo}{suffix}")
+}
+
+fn is_under_configured_api_base(url: &Url, api_base_url: &Url) -> bool {
+    url.scheme() == api_base_url.scheme()
+        && url.host_str() == api_base_url.host_str()
+        && url.port_or_known_default() == api_base_url.port_or_known_default()
+        && configured_api_path(url, api_base_url).is_some()
+}
+
+fn configured_api_path(url: &Url, api_base_url: &Url) -> Option<String> {
+    let url_path = url.path();
+    let base_path = api_base_url.path().trim_end_matches('/');
+    if base_path.is_empty() {
+        return Some(url_path.to_string());
+    }
+    if url_path == base_path {
+        return Some("/".into());
+    }
+    url_path
+        .strip_prefix(&format!("{base_path}/"))
+        .map(|rest| format!("/{rest}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn url(input: &str) -> Url {
+        Url::parse(input).unwrap()
+    }
+
+    fn options_with_github_api(server: &MockServer) -> VerifyOptions<'static> {
+        VerifyOptions::new(Some("test-token"), Url::parse(&server.uri()).unwrap())
+    }
 
     #[test]
     fn test_extract_urls() {
@@ -83,9 +365,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_all_ok() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("HEAD"))
-            .respond_with(wiremock::ResponseTemplate::new(200))
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
 
@@ -97,9 +379,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_broken_404() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("HEAD"))
-            .respond_with(wiremock::ResponseTemplate::new(404))
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(404))
             .mount(&server)
             .await;
 
@@ -118,13 +400,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_405_fallback_to_get_ok() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("HEAD"))
-            .respond_with(wiremock::ResponseTemplate::new(405))
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(405))
             .mount(&server)
             .await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(wiremock::ResponseTemplate::new(200))
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
             .mount(&server)
             .await;
 
@@ -136,13 +418,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_405_fallback_to_get_404() {
-        let server = wiremock::MockServer::start().await;
-        wiremock::Mock::given(wiremock::matchers::method("HEAD"))
-            .respond_with(wiremock::ResponseTemplate::new(405))
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(405))
             .mount(&server)
             .await;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .respond_with(wiremock::ResponseTemplate::new(404))
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404))
             .mount(&server)
             .await;
 
@@ -151,5 +433,259 @@ mod tests {
         let broken = verify(&[&text]).await;
         assert_eq!(broken.len(), 1);
         assert!(broken[0].1.contains("404"));
+    }
+
+    #[test]
+    fn test_github_classifier_accepts_exact_hosts() {
+        let options = VerifyOptions::default();
+        assert_eq!(
+            github_api_path_for(
+                &url("https://github.com/owner/repo/pull/7"),
+                &options.github_api_base_url
+            ),
+            Some("/repos/owner/repo/pulls/7".into())
+        );
+        assert_eq!(
+            github_api_path_for(
+                &url("https://api.github.com/repos/owner/repo/issues/7"),
+                &options.github_api_base_url
+            ),
+            Some("/repos/owner/repo/issues/7".into())
+        );
+    }
+
+    #[test]
+    fn test_github_classifier_rejects_spoofed_hosts() {
+        let options = VerifyOptions::default();
+        for input in [
+            "http://github.com/owner/repo/pull/7",
+            "https://github.com.evil.com/owner/repo/pull/7",
+            "https://owner.github.io/repo/pull/7",
+            "https://raw.githubusercontent.com/owner/repo/main/README.md",
+        ] {
+            assert_eq!(
+                github_api_path_for(&url(input), &options.github_api_base_url),
+                None,
+                "{input} must not be classified as GitHub API-verifiable"
+            );
+        }
+    }
+
+    #[test]
+    fn test_github_browser_urls_map_to_api_paths() {
+        let options = VerifyOptions::default();
+        for (input, expected) in [
+            ("https://github.com/owner/repo", "/repos/owner/repo"),
+            (
+                "https://github.com/owner/repo/pull/123",
+                "/repos/owner/repo/pulls/123",
+            ),
+            (
+                "https://github.com/owner/repo/issues/456",
+                "/repos/owner/repo/issues/456",
+            ),
+            (
+                "https://github.com/owner/repo/commit/abcdef",
+                "/repos/owner/repo/commits/abcdef",
+            ),
+            (
+                "https://github.com/owner/repo/releases",
+                "/repos/owner/repo/releases",
+            ),
+            (
+                "https://github.com/owner/repo/releases/tag/v1.2.3",
+                "/repos/owner/repo/releases/tags/v1.2.3",
+            ),
+            (
+                "https://github.com/owner/repo/releases/tag/release%2F2026",
+                "/repos/owner/repo/releases/tags/release%2F2026",
+            ),
+            (
+                "https://github.com/owner/repo/releases/latest",
+                "/repos/owner/repo/releases/latest",
+            ),
+            (
+                "https://github.com/owner/repo/compare/v1.0.0...v1.1.0",
+                "/repos/owner/repo/compare/v1.0.0...v1.1.0",
+            ),
+        ] {
+            assert_eq!(
+                github_api_path_for(&url(input), &options.github_api_base_url),
+                Some(expected.into()),
+                "{input}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_github_browser_urls_reject_unhandled_paths_and_bad_numbers() {
+        let options = VerifyOptions::default();
+        for input in [
+            "https://github.com",
+            "https://github.com/owner/repo/pull/not-a-number",
+            "https://github.com/owner/repo/issues/0",
+            "https://github.com/owner/repo/pull/123/files",
+            "https://github.com/owner/repo/blob/main/README.md",
+        ] {
+            assert_eq!(
+                github_api_path_for(&url(input), &options.github_api_base_url),
+                None,
+                "{input} must not be classified as API-verifiable"
+            );
+        }
+
+        assert_eq!(
+            github_api_path_for(
+                &url("https://github.com/owner/repo/commits/abcdef"),
+                &options.github_api_base_url
+            ),
+            Some("/repos/owner/repo/commits/abcdef".into())
+        );
+        assert_eq!(
+            github_api_path_for(
+                &url("https://github.com/owner/repo/releases/tag/release/2026/04"),
+                &options.github_api_base_url
+            ),
+            Some("/repos/owner/repo/releases/tags/release/2026/04".into())
+        );
+    }
+
+    #[test]
+    fn test_configured_github_api_base_path_mapping() {
+        let api_base_url = Url::parse("https://github.example.test/api/v3/").unwrap();
+        assert_eq!(
+            github_api_path_for(
+                &url("https://github.example.test/api/v3/repos/owner/repo/pulls/1"),
+                &api_base_url
+            ),
+            Some("/repos/owner/repo/pulls/1".into())
+        );
+        assert_eq!(
+            github_api_path_for(&url("https://github.example.test/api/v3"), &api_base_url),
+            Some("/".into())
+        );
+        assert_eq!(
+            github_api_path_for(
+                &url("https://github.example.test/other/repos/owner/repo/pulls/1"),
+                &api_base_url
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_github_status_reasons_preserve_actionable_context() {
+        assert!(github_api_status_reason(StatusCode::UNAUTHORIZED).contains("rejected"));
+        assert!(github_api_status_reason(StatusCode::FORBIDDEN).contains("permissions"));
+        assert!(github_api_status_reason(StatusCode::NOT_FOUND).contains("lacks access"));
+        assert_eq!(github_api_status_reason(StatusCode::BAD_GATEWAY), "502");
+
+        assert!(
+            github_browser_status_reason(StatusCode::FORBIDDEN, true)
+                .contains("checked without authentication")
+        );
+        assert!(
+            github_browser_status_reason(StatusCode::NOT_FOUND, false).contains("GITHUB_TOKEN")
+        );
+        assert_eq!(
+            github_browser_status_reason(StatusCode::BAD_GATEWAY, true),
+            "502"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verify_github_browser_link_uses_api_with_auth() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/123"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let text = "See https://github.com/owner/repo/pull/123";
+        let broken = verify_with_options(&[text], &options_with_github_api(&server)).await;
+        assert!(broken.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_verify_github_api_link_uses_auth() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/issues/123"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let text = format!("See {}/repos/owner/repo/issues/123", server.uri());
+        let broken = verify_with_options(&[&text], &options_with_github_api(&server)).await;
+        assert!(broken.is_empty());
+    }
+
+    #[test]
+    fn test_verify_github_link_without_token_reports_access_hint() {
+        assert!(
+            github_browser_status_reason(StatusCode::NOT_FOUND, false).contains("GITHUB_TOKEN")
+        );
+        assert!(
+            github_browser_status_reason(StatusCode::FORBIDDEN, false).contains("GITHUB_TOKEN")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_github_link_never_receives_auth() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let text = format!("See {}/page", server.uri());
+        let options = VerifyOptions::new(
+            Some("test-token"),
+            Url::parse(DEFAULT_GITHUB_API_BASE_URL).unwrap(),
+        );
+        let broken = verify_with_options(&[&text], &options).await;
+        assert!(broken.is_empty());
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(!requests.is_empty());
+        assert!(
+            requests
+                .iter()
+                .all(|request| !request.headers.contains_key("authorization"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_authenticated_github_api_does_not_follow_cross_host_redirect() {
+        let github_api = MockServer::start().await;
+        let redirected = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/pulls/123"))
+            .and(header("Authorization", "Bearer test-token"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("Location", format!("{}/capture", redirected.uri())),
+            )
+            .expect(1)
+            .mount(&github_api)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&redirected)
+            .await;
+
+        let text = "See https://github.com/owner/repo/pull/123";
+        let broken = verify_with_options(&[text], &options_with_github_api(&github_api)).await;
+        assert_eq!(broken.len(), 1);
+        assert!(broken[0].1.contains("302"));
+
+        let redirected_requests = redirected.received_requests().await.unwrap();
+        assert!(redirected_requests.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Use `GITHUB_TOKEN` to verify recognized GitHub browser links through the GitHub API.
- Preserve unauthenticated verification for non-GitHub URLs and existing `HEAD` to `GET` fallback behavior.
- Add regression coverage for GitHub URL classification, API mapping, auth boundaries, redirect safety, and agent link verification.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `cargo test links`
- `cargo test`

---

<details>

<summary>📋 Implementation Plan</summary>

# Plan: Use `GITHUB_TOKEN` for private GitHub link verification

## Goal

Fix the gap where Communiqué uses `GITHUB_TOKEN` for GitHub API PR/issue/release operations, but verifies generated links with an unauthenticated HTTP client. The intended outcome is that links to private GitHub repositories can pass verification when the configured `GITHUB_TOKEN` has access, while preserving existing behavior for public/non-GitHub links.

## Evidence from exploration

- `src/generate.rs` reads only `GITHUB_TOKEN` and builds `GitHubClient` when present.
- `src/github.rs` uses `.bearer_auth(&self.token)` for GitHub API calls including PRs, PR diffs, issues, release lookup, recent releases, and release update.
- `src/git.rs` tag discovery is local git-based and does not need GitHub auth.
- `src/links.rs::verify(texts: &[&str])` creates a separate `reqwest::Client` without `Authorization` headers.
- `src/agent.rs` calls `links::verify(&[&parsed.changelog, &parsed.release_body])`; it does not pass token/auth context.
- Link verification is enabled by default for non-dry-run flows via `ctx.defaults.verify_links.unwrap_or(true)`.

## Constraints and design principles

- Make the smallest surgical change that addresses the private-repo link-checking failure.
- Preserve unauthenticated behavior for non-GitHub URLs.
- Avoid sending GitHub tokens to arbitrary domains.
- Keep existing PR/issue/release API behavior unchanged.
- Prefer quick failures/assertions for impossible internal assumptions, but do not use assertions as user-facing error handling.
- Add tests that prove tokens are sent only where intended.

## Proposed implementation

### Phase 1 — Thread explicit verification options into link verification

1. Change `src/links.rs` from a bare function:

   ```rust
   pub async fn verify(texts: &[&str]) -> Vec<(String, String)>
   ```

   to an options-based API, for example:

   ```rust
   pub struct VerifyOptions<'a> {
       pub github_token: Option<&'a str>,
       pub github_api_base_url: url::Url,
   }

   pub async fn verify(texts: &[&str], options: &VerifyOptions<'_>) -> Vec<(String, String)>
   ```

   `github_api_base_url` should default to `https://api.github.com` in production and be injectable in tests.

2. Update all call sites and tests accordingly.

3. Prefer passing `github_token.as_deref()` through `AgentContext` from `src/generate.rs`, instead of exposing the token from `GitHubClient`. If a `GitHubClient::token()` accessor is still the least-churn option, keep it `pub(crate)`, assert it is non-empty in debug builds, and never log or derive `Debug` output containing it.

### Phase 2 — Verify common GitHub browser links through the GitHub API

Direct `Authorization: Bearer` requests to `https://github.com/...` browser pages may not reliably authenticate private repository pages. Make API-based verification the primary path for common GitHub links when a token is available.

1. Add a small parser/classifier in `src/links.rs` for exact GitHub URLs:

   - require `https` scheme,
   - require host exactly `github.com` or `api.github.com`,
   - reject spoofed or unrelated hosts such as `github.com.evil.com`, `*.github.io`, and arbitrary `githubusercontent.com` domains unless explicitly added later.

2. For recognized `github.com/{owner}/{repo}/...` browser paths and a present token, verify via `api.github.com` endpoints rather than browser-page `HEAD`/`GET`:

   - repo root: `GET /repos/{owner}/{repo}`
   - pull request: `GET /repos/{owner}/{repo}/pulls/{number}`
   - issue: `GET /repos/{owner}/{repo}/issues/{number}`
   - commit: `GET /repos/{owner}/{repo}/commits/{sha}`
   - release tag: `GET /repos/{owner}/{repo}/releases/tags/{tag}`
   - latest release: `GET /repos/{owner}/{repo}/releases/latest`
   - compare: `GET /repos/{owner}/{repo}/compare/{base}...{head}`

3. For `api.github.com` links, allow authenticated verification only when the URL is `https://api.github.com/...` or under the configured test API base URL.

4. For unrecognized GitHub browser paths, either:

   - fall back to direct authenticated verification with conservative redirect handling, or
   - leave the existing unauthenticated generic verifier in place but emit a clearer “could not verify private GitHub link shape” diagnostic.

   Prefer the smallest implementation that covers generated PR/issue/commit/release links first.

### Phase 3 — Preserve generic link behavior and prevent token leakage

1. Keep existing unauthenticated `HEAD` with `GET` fallback for non-GitHub links.

2. Apply bearer auth per request only after the GitHub URL classifier approves the exact scheme/host/path. Never set token headers globally on the `reqwest::Client`.

3. For any authenticated direct HTTP fallback, do not rely on default redirect behavior for safety. Either disable redirects for authenticated fallback requests or manually allow redirects only to the same trusted `https` host. Add a regression test proving auth is not sent across a cross-host redirect.

4. Consider `raw.githubusercontent.com` only if release notes commonly include private raw-file links; do not include wildcard `*.githubusercontent.com` support in this fix.

### Phase 4 — Improve diagnostics without changing core behavior

1. When a GitHub link fails with `401`, `403`, or `404` and no token was available, return/log a clearer reason such as:

   - `GitHub link is inaccessible or unverified; it may require GITHUB_TOKEN access`

2. When a token is available but the link still fails:

   - preserve the actual HTTP status,
   - for `403`, hint that token permissions/scopes may be insufficient,
   - avoid phrasing valid private links as simply “broken” when the result is really “not authorized” or “unverified.”

3. Keep diagnostics concise; do not introduce a new configuration surface unless needed.

### Phase 5 — Tests

Add/adjust tests in `src/links.rs` and any affected `src/agent.rs` tests.

Minimum test coverage:

1. Existing public-link behavior still passes without a token.
2. Broken public link still reports as broken.
3. Existing `405` HEAD fallback to GET still works without a token.
4. URL classifier accepts only exact `https://github.com` and `https://api.github.com` GitHub hosts.
5. URL classifier rejects `http://github.com`, `github.com.evil.com`, `*.github.io`, and unrelated `githubusercontent.com` hosts.
6. Common GitHub browser URLs map to the expected API endpoints for repo root, PR, issue, commit, release tag, latest release, and compare links.
7. API verification sends `Authorization: Bearer <token>` when token is provided.
8. GitHub-hosted link does not receive auth when token is absent and can fail with the expected inaccessible/unverified diagnostic.
9. Non-GitHub link never receives `Authorization`, even when token is provided.
10. Authenticated direct fallback, if implemented, does not leak auth across a cross-host redirect.
11. Existing agent link-verification tests are updated to pass verification options and still exercise retry behavior.

Implementation note: keep the parser/API mapping helpers small and pure so most host/path behavior can be unit-tested without network setup. Use the injectable `github_api_base_url` for deterministic `wiremock` tests of authenticated API requests.

### Phase 6 — Validation and quality gates

After implementation, run:

1. `cargo fmt --check`
2. `cargo test links`
3. `cargo test agent::tests::test_verify_links` or equivalent targeted agent tests
4. `cargo test`
5. `cargo clippy`

Fix all failures caused by the change before reporting completion.

## Dogfooding plan

Because this is CLI/link-checking behavior, dogfooding should verify both automated behavior and user-facing output.

1. Create or use a temporary private GitHub repository that the test `GITHUB_TOKEN` can read.
2. Generate release notes or run the smallest CLI flow that triggers link verification with a private `https://github.com/<owner>/<private-repo>/...` link.
3. Run once **without** `GITHUB_TOKEN` and capture:
   - terminal output screenshot,
   - terminal session recording,
   - expected inaccessible/private-link diagnostic.
4. Run again **with** `GITHUB_TOKEN` and capture:
   - terminal output screenshot,
   - terminal session recording,
   - successful verification/no false broken-link result.
5. Run with a non-GitHub URL while `GITHUB_TOKEN` is set and confirm, via test or local mock server logs, that no `Authorization` header is sent.
6. Attach screenshots/recordings to the implementation summary or PR notes so reviewers can inspect the exact behavior.

Suggested commands for dogfooding, adjusted to the repo’s actual CLI syntax after checking `--help`:

```bash
cargo build
cargo run -- --help
# Then run the minimal generation command against the private repo with verify_links enabled.
```

## Acceptance criteria

- `GITHUB_TOKEN` continues to be used for PR/issue/release GitHub API calls as before.
- Link verification verifies common private GitHub browser URLs for PRs, issues, commits, releases, repo roots, and compares through the GitHub API when the token has access.
- Link verification does not send the token to non-GitHub URLs or spoofed GitHub-like hosts.
- Private GitHub repository links accessible to the token no longer fail solely because verification is unauthenticated or because browser-page auth is unreliable.
- Existing public-link and generic `HEAD`→`GET` fallback behavior remains intact.
- Tests cover URL classification, GitHub browser-to-API mapping, auth/no-auth boundaries, redirect safety, and existing retry behavior.
- Formatting, tests, and clippy pass.
- Dogfooding evidence includes screenshots and a recording for both failure-before/success-after style CLI runs, or a documented blocker if private-repo dogfooding cannot be performed.

## Risks and mitigations

- **Risk: token leakage to non-GitHub domains.** Mitigate with exact `https` host classification, per-request auth, and tests for spoofed hosts and non-GitHub URLs.
- **Risk: private `github.com` browser URLs may not respond to bearer-auth HEAD/GET.** Mitigate by making GitHub browser-link verification API-based for common generated links instead of relying on browser-page authentication.
- **Risk: redirects could obscure auth behavior.** Mitigate by disabling redirects or allowing only same trusted `https` host redirects for authenticated direct fallback, plus a cross-host redirect regression test.
- **Risk: GitHub URL path coverage is incomplete.** Mitigate by covering the common links Communiqué generates first and producing an explicit “unrecognized/unverified GitHub link” diagnostic for uncommon paths.
- **Risk: only `GITHUB_TOKEN` is supported.** This is existing behavior; defer `GH_TOKEN` support unless requested to keep the fix minimal.

</details>

---
_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh`_
