### PR TITLE
chore: add plausible analytics

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,15 @@ export default defineConfig({
     ],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { name: "twitter:card", content: "summary" }],
+    [
+      "script",
+      {
+        defer: "",
+        "data-domain": "communique.jdx.dev",
+        "data-api": "https://shrill.en.dev/f5f1/event",
+        src: "https://shrill.en.dev/shrill/script.js",
+      },
+    ],
   ],
 
   themeConfig: {


### PR DESCRIPTION
Adds Plausible Analytics to the docs site via the shrill.en.dev Cloudflare worker proxy.

`data-domain="communique.jdx.dev"` matches the Pages custom domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a docs-only change that injects a third-party analytics script; main risk is unintended tracking/perf impact or misconfigured endpoint.
> 
> **Overview**
> Adds Plausible Analytics to the VitePress docs site by injecting a deferred `script` tag into `docs/.vitepress/config.mts` `head`, configured with `data-domain="communique.jdx.dev"` and a proxied `data-api`/`src` at `shrill.en.dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff222d2288ec7345e6924fac6bdde395ceacea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->