### PR TITLE
chore: bump hk to 1.44.3

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.35.0/hk@1.35.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.35.0/hk@1.35.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtins.pkl"
 
 local linters = new Mapping<String, Step> {
     ["cargo-clippy"] = Builtins.cargo_clippy


### PR DESCRIPTION
Bumps the hk pre-commit pin to v1.44.3. See https://github.com/jdx/hk/releases/tag/v1.44.3 for changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the pinned `hk` package version used for hooks, without changing hook configuration or logic.
> 
> **Overview**
> Updates `hk.pkl` to pin `hk` from v1.35.0 to v1.44.3 by changing the imported `Config.pkl` and `Builtins.pkl` package URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66130527b064bcd03ca1c88776df2b3106a74cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->