### PR TITLE
ci: pin taiki-e/install-action to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add clippy rustfmt
-      - uses: taiki-e/install-action@cargo-audit
+      - uses: taiki-e/install-action@cd1c8251b429e645b6b4fef021814af1150c1f22 # cargo-audit
       - run: mise run lint
       - run: mise x -- cargo test
       - run: cargo audit
@@ -26,7 +26,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@d79fce544138636ae8155ecac335f73c98e3b198 # cargo-llvm-cov
       - run: mise x -- cargo llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:


### PR DESCRIPTION
## Summary
- Pin `taiki-e/install-action@cargo-audit` and `taiki-e/install-action@cargo-llvm-cov` to full-length commit SHAs in `ci.yml`. Both refs are tool-alias tags the action's CI auto-bumps; SHA-pinning is required by org policy regardless.

## Test plan
- [ ] CI workflow still installs cargo-audit + cargo-llvm-cov on next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only CI workflow action references changed, with no impact on runtime code; the main risk is CI breakage if the pinned SHAs become unavailable or differ from the previous moving tags.
> 
> **Overview**
> Pins `taiki-e/install-action` in `.github/workflows/ci.yml` to full commit SHAs for the `cargo-audit` and `cargo-llvm-cov` installs, replacing the previous tool-alias refs.
> 
> No other CI steps or build/test commands are changed; this primarily improves supply-chain reproducibility and compliance with SHA-pinning policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4c8f5a04a9ffc4fb36b0abd5875b6677f6ec5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->