### PR TITLE
chore(docs): remove shrill.en.dev analytics script

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,15 +43,6 @@ export default defineConfig({
     ],
     ["meta", { property: "og:type", content: "website" }],
     ["meta", { name: "twitter:card", content: "summary" }],
-    [
-      "script",
-      {
-        defer: "",
-        "data-domain": "communique.jdx.dev",
-        "data-api": "https://shrill.en.dev/f5f1/event",
-        src: "https://shrill.en.dev/shrill/script.js",
-      },
-    ],
   ],
 
   themeConfig: {


### PR DESCRIPTION
Removes the proxied shrill.en.dev analytics snippet from the VitePress docs config — the endpoint is going away.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a third-party analytics script include from the docs site head, with no application logic or data flow changes.
> 
> **Overview**
> Removes the `shrill.en.dev` analytics snippet (the deferred `<script>` with `data-domain`/`data-api`) from the VitePress docs `head` config, stopping docs pages from loading and sending events to that endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883826e865a06f403e7e5efe6b7f632c09731546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->