### PR TITLE
v1.2.0: Sponsors command & Opus 4.8 default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.0](https://github.com/jdx/communique/releases/tag/v1.2.0) - 2026-06-24
+
+## Added
+
+- Added a `communique sponsors` command that lists the companies sponsoring communique and the en.dev project family ([#174](https://github.com/jdx/communique/pull/174))
+
+## Changed
+
+- Bumped the built-in Anthropic default model from `claude-opus-4-7` to `claude-opus-4-8` ([#197](https://github.com/jdx/communique/pull/197))
+
+## Fixed
+
+- Updated the locked `quinn-proto` dependency (0.11.14 → 0.11.15) to resolve RustSec advisory RUSTSEC-2026-0185 ([#199](https://github.com/jdx/communique/pull/199))
+- Granted `contents: write` to the release asset workflow so prebuilt binaries upload correctly ([#200](https://github.com/jdx/communique/pull/200))
+
 ## [1.1.3](https://github.com/jdx/communique/releases/tag/v1.1.3) - 2026-05-06
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.1.3"
+version = "1.2.0"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.1.3"
+version "1.2.0"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.1.3",
+  "version": "1.2.0",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.1.3
+**Version**: 1.2.0
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small release that adds a `sponsors` command, bumps the default Anthropic model to Opus 4.8, and pulls in a security fix for a transitive QUIC dependency.

## Added

- **`communique sponsors` command** — A new read-only subcommand that prints the companies sponsoring communique and the broader en.dev project family, with a link to the full sponsor list. ([#174](https://github.com/jdx/communique/pull/174)) (@jdx)

  ```sh
  $ communique sponsors
  communique and the en.dev project family are sponsored by:

    37signals - https://37signals.com

  View all sponsors: https://en.dev/sponsors.html
  ```

## Changed

- **Default model bumped to `claude-opus-4-8`** — When no `--model` flag or `communique.toml` override is set, communique now defaults to `claude-opus-4-8` (previously `claude-opus-4-7`). Explicit model overrides are unaffected. ([#197](https://github.com/jdx/communique/pull/197)) (@jdx)

## Fixed

- **Security advisory RUSTSEC-2026-0185** — Updated the locked `quinn-proto` dependency from 0.11.14 to 0.11.15 (a transitive part of the QUIC stack used by `reqwest`) to clear `cargo audit`. ([#199](https://github.com/jdx/communique/pull/199)) (@jdx)
- **Release asset uploads** — Granted `contents: write` to the reusable upload-assets workflow so prebuilt binaries are published with releases instead of failing permission validation. ([#200](https://github.com/jdx/communique/pull/200)) (@jdx)

## 💚 Sponsor communique

communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic in this diff; behavior shipped in earlier PRs.
> 
> **Overview**
> **Release cut for v1.2.0** — bumps the crate and CLI metadata from `1.1.3` to `1.2.0` in `Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and generated CLI docs (`docs/cli/commands.json`, `docs/cli/index.md`).
> 
> **CHANGELOG** — adds a dated **1.2.0** section (sponsors command, default model `claude-opus-4-8`, `quinn-proto` security bump, release workflow `contents: write` fix) and leaves **`[Unreleased]`** with a **Changed** note that the default model is now Opus 4.8 for the next development cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a202c1ad1883d7c0136e6164d9401240c75c84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->