### PR TITLE
chore(ci): assert mise run render produces no diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # cargo-audit
+      - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff
+            exit 1
+          fi
       - run: mise run lint
       - run: mise x -- cargo test
       - run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::'mise run render' produced changes. Run it locally and commit."
             git status
-            git diff
+            git diff HEAD
             exit 1
           fi
       - run: mise run lint


### PR DESCRIPTION
Runs `mise run render` and asserts it produces no diff. Follows up the autofix.ci workflow removal in #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that may surface new CI failures if generated artifacts are out of date, but does not affect runtime code.
> 
> **Overview**
> Adds a CI guardrail to run `mise run render` and **fail the job if it produces a git diff**, ensuring generated/rendered outputs are committed before lint/tests/audit run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 471738df89cd3f65f0eff70e33dc6a0a63fb2329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->