### PR TITLE
chore(ci): add zizmor workflow for github actions security analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add clippy rustfmt
@@ -30,8 +36,12 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add llvm-tools-preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add clippy rustfmt
-      - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # cargo-audit
+      - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
       - run: mise run render
       - name: assert render produces no diff
         run: |
@@ -45,7 +45,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # cargo-llvm-cov
+      - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - run: mise x -- cargo llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,7 @@ on:
       - docs/**
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -20,11 +17,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -56,6 +56,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     name: Deploy
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -43,7 +43,7 @@ jobs:
           # Draft releases created before the tag exists get an "untagged-*" tag_name.
           # Patch each draft release to use the correct tag.
           # Retry because the GitHub API may not immediately list the new release.
-          for tag in $(echo '${STEPS_RELEASE_PLZ_OUTPUTS_RELEASES}' | jq -r '.[].tag'); do
+          for tag in $(echo "${STEPS_RELEASE_PLZ_OUTPUTS_RELEASES}" | jq -r '.[].tag'); do
             echo "Looking for untagged draft release to fix for tag: $tag"
             release_id=""
             for attempt in $(seq 1 10); do
@@ -139,12 +139,13 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # release-plz-pr needs persisted credentials so the later
+      # `git push --force-with-lease` can authenticate.
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # zizmor: ignore[artipacked] v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
@@ -162,7 +163,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           STEPS_RELEASE_PLZ_OUTPUTS_PR: ${{ steps.release-plz.outputs.pr }}
         run: |
-          PR_NUMBER=$(echo '${STEPS_RELEASE_PLZ_OUTPUTS_PR}' | jq -r '.number')
+          PR_NUMBER=$(echo "${STEPS_RELEASE_PLZ_OUTPUTS_PR}" | jq -r '.number')
           gh pr checkout "$PR_NUMBER"
 
           # Build, regenerate usage spec + docs, and fix linting in parallel

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   release-plz-release:
     name: Release-plz release
@@ -19,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
         id: release-plz
@@ -35,11 +38,12 @@ jobs:
         if: steps.release-plz.outputs.releases_created == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          STEPS_RELEASE_PLZ_OUTPUTS_RELEASES: ${{ steps.release-plz.outputs.releases }}
         run: |
           # Draft releases created before the tag exists get an "untagged-*" tag_name.
           # Patch each draft release to use the correct tag.
           # Retry because the GitHub API may not immediately list the new release.
-          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[].tag'); do
+          for tag in $(echo '${STEPS_RELEASE_PLZ_OUTPUTS_RELEASES}' | jq -r '.[].tag'); do
             echo "Looking for untagged draft release to fix for tag: $tag"
             release_id=""
             for attempt in $(seq 1 10); do
@@ -66,7 +70,9 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}
-    secrets: inherit
+    secrets:
+      CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+      CERTIFICATES_P12_PASS: ${{ secrets.CERTIFICATES_P12_PASS }}
 
   publish-release:
     name: Publish release
@@ -79,7 +85,8 @@ jobs:
       - name: Publish GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-        run: gh release edit "${{ needs.release-plz-release.outputs.tag }}" --repo jdx/communique --draft=false
+          NEEDS_RELEASE_PLZ_RELEASE_OUTPUTS_TAG: ${{ needs.release-plz-release.outputs.tag }}
+        run: gh release edit "${NEEDS_RELEASE_PLZ_RELEASE_OUTPUTS_TAG}" --repo jdx/communique --draft=false
 
   enhance-release:
     name: Enhance release notes
@@ -92,14 +99,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
+          persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Enhance GitHub release with communique
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NEEDS_RELEASE_PLZ_RELEASE_OUTPUTS_TAG: ${{ needs.release-plz-release.outputs.tag }}
         run: |
           cargo build
-          ./target/debug/communique generate "${{ needs.release-plz-release.outputs.tag }}" --github-release
+          ./target/debug/communique generate "${NEEDS_RELEASE_PLZ_RELEASE_OUTPUTS_TAG}" --github-release
       - name: Append en.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -135,6 +144,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
@@ -150,8 +160,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          STEPS_RELEASE_PLZ_OUTPUTS_PR: ${{ steps.release-plz.outputs.pr }}
         run: |
-          PR_NUMBER=$(echo '${{ steps.release-plz.outputs.pr }}' | jq -r '.number')
+          PR_NUMBER=$(echo '${STEPS_RELEASE_PLZ_OUTPUTS_PR}' | jq -r '.number')
           gh pr checkout "$PR_NUMBER"
 
           # Build, regenerate usage spec + docs, and fix linting in parallel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
       tag:
         required: true
         type: string
+    secrets:
+      CERTIFICATES_P12:
+        required: true
+      CERTIFICATES_P12_PASS:
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -38,6 +43,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
       - name: Import codesign certs
         if: startsWith(matrix.os, 'macos')
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,3 +17,5 @@ jobs:
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,19 @@
+name: zizmor
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: ['.github/workflows/**']
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths: ['.github/workflows/**']
+    paths: [".github/workflows/**"]
 
 permissions: {}
 


### PR DESCRIPTION
Adds [zizmor](https://github.com/zizmorcore/zizmor) to audit GitHub Actions workflows for security issues. Runs on push to main and on PRs that change `.github/workflows/**`. Fails CI on any finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes multiple GitHub Actions workflows (permissions, credential persistence, and release secrets wiring), which could break CI/release automation if misconfigured.
> 
> **Overview**
> Adds a new `zizmor` GitHub Actions workflow to statically analyze workflows on PRs touching `.github/workflows/**` and on pushes to `main`.
> 
> Hardens existing workflows by defaulting to `permissions: {}` at the workflow level, scoping job permissions explicitly, and disabling checkout credential persistence via `persist-credentials: false` (except where release automation requires it). Also tightens release automation by passing required signing secrets explicitly to the reusable `release.yml` workflow and refactoring some expressions into env vars for safer shell usage, plus adding targeted `zizmor` ignore annotations for tag-only action refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f775a6ef38a131ba1da16633d1b3747aeae6cd4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->