### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ publish directly to a GitHub Release.
 
 communique is sponsored by [37signals](https://37signals.com).
 
+[View all sponsors](https://en.dev/sponsors.html).
+
 ## Install
 
 Install with [mise](https://mise.jdx.dev):


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation change with no code or runtime impact.
> 
> **Overview**
> Adds a **[View all sponsors](https://en.dev/sponsors.html)** link in the README **Sponsors** section, directly under the existing 37signals mention, so readers can open the full en.dev sponsors page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e70637ad6a1d80d20b82e258767b03116845875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "View all sponsors" link to the Sponsors section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->