### PR TITLE
chore(ci): use shared coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+remote_config:
+  repository: "jdx/coderabbit"
+  ref: "main"
+  path: ".coderabbit.yaml"


### PR DESCRIPTION
## Summary
- Point this repository's CodeRabbit YAML at the shared `jdx/coderabbit` configuration.
- Keep CodeRabbit settings centralized across the en.dev CLI repositories.

## Validation
- YAML-only configuration change; not run.

*This PR was created by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI/tooling configuration with no application, auth, or runtime behavior changes.
> 
> **Overview**
> Adds a **`.coderabbit.yaml`** that pulls CodeRabbit review settings from the shared **`jdx/coderabbit`** repo (`main` branch) instead of maintaining a full local config in this repository.
> 
> The file includes the CodeRabbit schema hint and a `remote_config` block (`repository`, `ref`, `path`) so behavior stays aligned with other en.dev CLI repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f53fa130550dac73ec91c68cf645f5c90f7beb46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->