### PR TITLE
Bump default Opus model to 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
+
 ## [1.1.3](https://github.com/jdx/communique/releases/tag/v1.1.3) - 2026-05-06
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Avoid marketing language.
 """
 
 [defaults]
-model = "claude-opus-4-7"
+model = "claude-opus-4-8"
 repo = "owner/repo"
 max_tokens = 4096
 ```
@@ -180,7 +180,7 @@ examples and release PR workflows.
 
 ```sh
 communique generate v1.2.0 --repo owner/repo
-communique generate v1.2.0 --model claude-opus-4-7
+communique generate v1.2.0 --model claude-opus-4-8
 communique generate v1.2.0 --provider openai --base-url https://api.example.com/v1
 communique generate v1.2.0 --quiet
 communique generate v1.2.0 --verbose

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -36,14 +36,14 @@ Default parameters for generation. All values can be overridden via CLI flags.
 
 ```toml
 [defaults]
-model = "claude-opus-4-7"
+model = "claude-opus-4-8"
 max_tokens = 4096
 repo = "owner/repo"
 ```
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `model` | Model identifier | `claude-opus-4-7` |
+| `model` | Model identifier | `claude-opus-4-8` |
 | `max_tokens` | Maximum response tokens | `4096` |
 | `repo` | GitHub repo in `owner/repo` format | Auto-detected from git remote |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ const TEMPLATE: &str = r#"# Extra instructions appended to the system prompt.
 #context = ""
 
 [defaults]
-#model = "claude-opus-4-7"
+#model = "claude-opus-4-8"
 #max_tokens = 4096
 #repo = "owner/repo"
 #provider = "anthropic"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -173,7 +173,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
         .model
         .clone()
         .or(defaults.model.clone())
-        .unwrap_or_else(|| "claude-opus-4-7".into());
+        .unwrap_or_else(|| "claude-opus-4-8".into());
     let max_tokens = opts.max_tokens.or(defaults.max_tokens).unwrap_or(4096);
     let owner_repo = match opts.repo.clone().or(defaults.repo.clone()) {
         Some(r) => r,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -31,7 +31,7 @@ mod tests {
 
     #[test]
     fn test_detect_provider_claude() {
-        assert_eq!(detect_provider("claude-opus-4-6"), Provider::Anthropic);
+        assert_eq!(detect_provider("claude-opus-4-8"), Provider::Anthropic);
         assert_eq!(
             detect_provider("claude-sonnet-4-5-20250929"),
             Provider::Anthropic


### PR DESCRIPTION
Summary:
- Bump the built-in Anthropic default from claude-opus-4-7 to claude-opus-4-8.
- Refresh the config template, docs examples, provider test fixture, and changelog note.

Test:
- cargo +1.96.0 test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and default-string updates only; explicit model overrides are unchanged.
> 
> **Overview**
> Updates the built-in Anthropic default from **`claude-opus-4-7`** to **`claude-opus-4-8`** when no `--model` or `communique.toml` override is set (`generate.rs` fallback).
> 
> The same identifier is reflected in the **`communique init`** template (`config.rs`), README and configuration guide examples, the provider detection test fixture, and an **[Unreleased]** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa970c16495ccecc43a4a2dd7445b12e1138524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->