### PR TITLE
Update quinn-proto for RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- update quinn-proto from 0.11.14 to 0.11.15 in Cargo.lock
- resolve cargo audit failure for RUSTSEC-2026-0185

## Verification
- PATH="/Users/jdx/src/communique/target/codex-tools/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Users/jdx/.local/bin:/Users/jdx/.cargo/bin:/Users/jdx/.codex/tmp/arg0/codex-arg0nkw4Ac:/Applications/Codex.app/Contents/Resources" cargo audit
- cargo +1.96.0 test

Note: local default rustc is 1.93.0, so tests were run with the installed 1.96.0 toolchain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch release for a known advisory; no direct code changes.
> 
> **Overview**
> Bumps the locked **`quinn-proto`** dependency from **0.11.14** to **0.11.15** in `Cargo.lock` (checksum updated). No application source changes—this is a transitive QUIC stack update (via **`quinn`**, used by **`reqwest`**) to clear **`cargo audit`** for **RUSTSEC-2026-0185**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e0e268b5a64c544c9a80ff3ecb1f995611317d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->