### PR TITLE
fix(ci): grant release asset workflow permissions

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,6 +67,8 @@ jobs:
     name: Upload assets
     needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}


### PR DESCRIPTION
## Summary
- Grant `contents: write` to the `upload-assets` reusable workflow call in `release-plz.yml`.
- Allows the called `release.yml` workflow to request the same permission instead of failing validation with `contents: none`.

## Verification
- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/release-plz.yml"); puts "release-plz.yml parses"'`\n- `mise run lint` *(fails before this YAML change is exercised: local rustc 1.93.0, `kdl@6.7.1` requires rustc 1.95)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI permission change with no application or security logic changes.
> 
> **Overview**
> The **`upload-assets`** job in `release-plz.yml` now sets **`contents: write`** before calling the reusable **`release.yml`** workflow.
> 
> The root workflow uses **`permissions: {}`**, so reusable calls inherit no write access unless the calling job explicitly grants it. Without this, GitHub rejects the call when **`release.yml`** requests **`contents: write`** (validation error: **`contents: none`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fba1727c95f72a8fc549ca642d99fe6ee0f7e376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->