### PR TITLE
v1.2.1: Maintenance & Branding Refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.1](https://github.com/jdx/communique/releases/tag/v1.2.1) - 2026-07-07
+
+## Added
+
+- MIT `LICENSE` file at the repo root, matching the `license = "MIT"` already declared in `Cargo.toml` ([#207](https://github.com/jdx/communique/pull/207))
+- Vaporwave logo and favicon set for the docs site and README ([#215](https://github.com/jdx/communique/pull/215))
+
+## Changed
+
+- Sponsor references now point at jdx.dev, and `entire.io` is listed as a title sponsor alongside 37signals in the `communique sponsors` command, help text, docs, and the appended release blurb ([#208](https://github.com/jdx/communique/pull/208))
+- Improved built-in release-note prompt calibration — important features get short command/config examples, and small releases stay compact instead of being padded ([#218](https://github.com/jdx/communique/pull/218))
+
 ## [1.2.0](https://github.com/jdx/communique/releases/tag/v1.2.0) - 2026-06-24
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.2.0"
+version "1.2.1"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.0
+**Version**: 1.2.1
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small maintenance release: refreshed sponsor branding for jdx.dev, a new vaporwave logo, an MIT license file, and tuning to the built-in release-note prompt. The bulk of this release is dependency and CI maintenance with no user-facing impact.

## Added

- **MIT `LICENSE` file** — Adds a root `LICENSE` with standard MIT text, matching the `license = "MIT"` already set in `Cargo.toml`. ([#207](https://github.com/jdx/communique/pull/207)) (@jdx)
- **Vaporwave logo and favicon** — communiqué gets its first visual branding: a neon speech-bubble mark with a retro slatted sun, wired into the docs site (favicon, apple-touch-icon, navbar, landing hero) and the README. ([#215](https://github.com/jdx/communique/pull/215)) (@jdx)

## Changed

- **Sponsor references moved to jdx.dev** — The `communique sponsors` command, help text, generated CLI docs, docs-site footer, and the appended release blurb now point at [jdx.dev/sponsors.html](https://jdx.dev/sponsors.html) and list `entire.io` as a title sponsor alongside 37signals. ([#208](https://github.com/jdx/communique/pull/208)) (@jdx)
- **Better release-note prompt calibration** — The built-in system prompt now guides the model to include short command/config examples for important user-facing features and to keep small releases compact and direct rather than padding them out. ([#218](https://github.com/jdx/communique/pull/218)) (@jdx)

## 💚 Sponsor communique

communique is developed by [@jdx](https://github.com/jdx) at [**jdx.dev**](https://jdx.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), aube, hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog/doc sync with no runtime or security logic changes in this diff.
> 
> **Overview**
> This PR cuts **v1.2.1** by bumping `version` from `1.2.0` to `1.2.1` in `Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and the generated CLI metadata (`docs/cli/commands.json`, `docs/cli/index.md`).
> 
> It adds a **`## [1.2.1]`** changelog section (2026-07-07) summarizing work already landed on the branch: root MIT **LICENSE**, vaporwave logo/favicon for docs and README, sponsor copy pointing at **jdx.dev** with **entire.io** as a title sponsor, and tighter built-in release-note prompt calibration. **`[Unreleased]`** still notes a pending default model bump to `claude-opus-4-8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ed2f23b18e1ae5d23b542d2c509ba40d0002d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->