### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           cargo build
           ./target/debug/communique generate "${NEEDS_RELEASE_PLZ_RELEASE_OUTPUTS_TAG}" --github-release
-      - name: Append en.dev sponsor blurb
+      - name: Append jdx.dev sponsor blurb
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           TAG: ${{ needs.release-plz-release.outputs.tag }}
@@ -124,9 +124,9 @@ jobs:
 
           ## 💚 Sponsor communique
 
-          communique is developed by [@jdx](https://github.com/jdx) at [**en.dev**](https://en.dev), an independent studio behind developer tools like [mise](https://mise.jdx.dev/), [aube](https://aube.en.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.
+          communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.
 
-          If communique is drafting your release notes or changelogs, please consider [sponsoring at en.dev](https://en.dev). Every sponsor — individual or company — helps keep the project independent and actively maintained.
+          If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.
           EOF
 
           gh release edit "$TAG" --notes-file /tmp/release-notes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Added a `communique sponsors` command that lists the companies sponsoring communique and the en.dev project family ([#174](https://github.com/jdx/communique/pull/174))
+- Added a `communique sponsors` command that lists the companies sponsoring communique and the jdx.dev open source tools ([#174](https://github.com/jdx/communique/pull/174))
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ publish directly to a GitHub Release.
 
 ## Sponsors
 
-communique is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+communique is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ publish directly to a GitHub Release.
 
 ## Sponsors
 
-communique is sponsored by [37signals](https://37signals.com).
+communique is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
 
-[View all sponsors](https://en.dev/sponsors.html).
+[View all sponsors](https://jdx.dev/sponsors.html).
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ publish directly to a GitHub Release.
 
 ## Sponsors
 
-communique is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
+communique is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -37,7 +37,7 @@ cmd generate help="Generate release notes for a git tag" {
 cmd init help="Generate a communique.toml config file in the repo root" {
     flag --force help="Overwrite existing config file"
 }
-cmd sponsors help="Show the companies sponsoring communique and the en.dev project family"
+cmd sponsors help="Show the companies sponsoring communique and the jdx.dev open source tools"
 cmd usage hide=#true help="Generates a usage spec for the CLI" {
     long_help "Generates a usage spec for the CLI\n\nhttps://usage.jdx.dev"
 }

--- a/docs/.vitepress/theme/EndevFooter.vue
+++ b/docs/.vitepress/theme/EndevFooter.vue
@@ -4,15 +4,15 @@
     <span aria-hidden="true">·</span>
     <span>Copyright © {{ year }}</span>
     <span aria-hidden="true">·</span>
-    <a class="EndevFooterLink" href="https://en.dev">
+    <a class="EndevFooterLink" href="https://jdx.dev">
       <img
         alt=""
         class="EndevFooterLogo"
         height="28"
-        src="https://github.com/endevco.png?size=96"
+        src="https://github.com/jdx.png?size=96"
         width="28"
       />
-      <span>en.dev</span>
+      <span>jdx.dev</span>
     </a>
   </footer>
 </template>

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -35,7 +35,7 @@ import { onMounted, ref } from "vue";
 
 const sponsors = ref([]);
 const error = ref(false);
-const footerTiers = new Set(["anchor", "premier", "partner"]);
+const footerTiers = new Set(["title", "premier", "partner"]);
 const sponsorFeedTimeoutMs = 5000;
 
 const sponsorItems = (items) => (Array.isArray(items) ? items : []);

--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -23,7 +23,7 @@
           <img :alt="sponsor.name" :src="sponsor.logo" loading="lazy" decoding="async" />
         </a>
       </div>
-      <a class="EndevSponsorsCta" href="https://en.dev/sponsors.html">
+      <a class="EndevSponsorsCta" href="https://jdx.dev/sponsors.html">
         View all sponsors
       </a>
     </div>
@@ -61,7 +61,7 @@ onMounted(async () => {
   const timeout = window.setTimeout(() => controller.abort(), sponsorFeedTimeoutMs);
 
   try {
-    const res = await fetch("https://en.dev/sponsors.json", {
+    const res = await fetch("https://jdx.dev/sponsors.json", {
       headers: { Accept: "application/json" },
       signal: controller.signal,
     });

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -246,7 +246,7 @@
         "flags": [],
         "mounts": [],
         "hide": false,
-        "help": "Show the companies sponsoring communique and the en.dev project family",
+        "help": "Show the companies sponsoring communique and the jdx.dev open source tools",
         "name": "sponsors",
         "aliases": [],
         "hidden_aliases": [],

--- a/docs/cli/sponsors.md
+++ b/docs/cli/sponsors.md
@@ -3,4 +3,4 @@
 
 - **Usage**: `communique sponsors`
 
-Show the companies sponsoring communique and the en.dev project family
+Show the companies sponsoring communique and the jdx.dev open source tools

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,7 @@ pub enum Command {
         force: bool,
     },
 
-    /// Show the companies sponsoring communique and the en.dev project family
+    /// Show the companies sponsoring communique and the jdx.dev open source tools
     Sponsors,
 
     Usage(usage::Usage),

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn init(force: bool) -> miette::Result<()> {
 
 fn sponsors() -> miette::Result<()> {
     println!(
-        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn init(force: bool) -> miette::Result<()> {
 
 fn sponsors() -> miette::Result<()> {
     println!(
-        "communique and the en.dev project family are sponsored by:\n\n  37signals - https://37signals.com\n\nView all sponsors: https://en.dev/sponsors.html"
+        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ fn init(force: bool) -> miette::Result<()> {
 
 fn sponsors() -> miette::Result<()> {
     println!(
-        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n  Supabase - https://supabase.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n  CodeRabbit - https://coderabbit.link/mise\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,9 +21,10 @@ fn test_sponsors_command() {
         result.status,
         stderr
     );
+    assert!(stdout.contains("entire.io"), "stdout: {stdout}");
     assert!(stdout.contains("37signals"), "stdout: {stdout}");
     assert!(
-        stdout.contains("https://en.dev/sponsors.html"),
+        stdout.contains("https://jdx.dev/sponsors.html"),
         "stdout: {stdout}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- list Entire first in the README and sponsors command
- point sponsor feed/page links at jdx.dev
- update docs sponsor/footer copy, tests, release blurb, and generated CLI docs

## Tests
- git diff --check
- npm run docs:build from docs/
- mise x rust@1.95.0 -- cargo run -q -p communique -- sponsors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, documentation, and sponsor URL changes only; no runtime or security-sensitive logic.
> 
> **Overview**
> Replaces **en.dev** sponsor branding with **jdx.dev** across the repo and adds **entire.io** as the title sponsor alongside 37signals.
> 
> The `communique sponsors` command, README, generated CLI docs, and `sponsors` help text now describe the **jdx.dev open source tools** and link to `https://jdx.dev/sponsors.html`. Docs site footer and sponsor widget load `jdx.dev/sponsors.json` and filter footer tiers using `title` instead of `anchor`.
> 
> The release workflow’s appended sponsor blurb is renamed and rewritten for jdx.dev / entire.io. Integration tests assert `entire.io` and the new sponsors URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d5299059a49c11132402a04f61e730f32bbd4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->