### PR TITLE
Add communique logo assets

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -29,6 +29,7 @@ export default defineConfig({
   lastUpdated: true,
 
   head: [
+    ["link", { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
     ["meta", { name: "theme-color", content: "#b967ff" }],
     [
       "meta",
@@ -46,6 +47,8 @@ export default defineConfig({
   ],
 
   themeConfig: {
+    logo: "/logo-mark.svg",
+
     nav: [
       { text: "Guide", link: "/guide/getting-started" },
       { text: "CLI Reference", link: "/cli/" },

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">communiqué favicon</title>
+  <desc id="desc">A neon document and signal mark forming a stylized C with an acute accent.</desc>
+  <defs>
+    <linearGradient id="mark-stroke" x1="42" y1="214" x2="220" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".52" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <linearGradient id="paper-fill" x1="82" y1="63" x2="172" y2="193" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#25103e"/>
+      <stop offset="1" stop-color="#0a0015"/>
+    </linearGradient>
+    <linearGradient id="accent-fill" x1="143" y1="47" x2="198" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".45" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <filter id="soft-glow" x="-35%" y="-35%" width="170%" height="170%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feColorMatrix in="blur" values="1 0 0 0 0.75 0 1 0 0 0.25 0 0 1 0 1 0 0 0 0.7 0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <clipPath id="fold-clip">
+      <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z"/>
+    </clipPath>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="#0a0015"/>
+  <path d="M180 44a88 88 0 1 0 0 168" fill="none" stroke="url(#mark-stroke)" stroke-width="18" stroke-linecap="round" filter="url(#soft-glow)"/>
+  <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z" fill="url(#paper-fill)" stroke="url(#mark-stroke)" stroke-width="8" stroke-linejoin="round"/>
+  <g clip-path="url(#fold-clip)">
+    <path d="M151 59v33a10 10 0 0 0 10 10h33z" fill="#120025" stroke="#01cdfe" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#e8d5f5" stroke-width="9" stroke-linecap="round"/>
+    <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#01cdfe" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  </g>
+  <path d="M146 46 196 20" fill="none" stroke="url(#accent-fill)" stroke-width="16" stroke-linecap="round" filter="url(#soft-glow)"/>
+  <path d="M185 68c16 5 28 16 35 31M196 47c22 8 39 24 49 45" fill="none" stroke="#01cdfe" stroke-width="7" stroke-linecap="round" opacity=".75"/>
+</svg>

--- a/docs/public/logo-mark.svg
+++ b/docs/public/logo-mark.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">communiqué mark</title>
+  <desc id="desc">A neon document and signal mark forming a stylized C with an acute accent.</desc>
+  <defs>
+    <linearGradient id="mark-stroke" x1="42" y1="214" x2="220" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".52" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <linearGradient id="paper-fill" x1="82" y1="63" x2="172" y2="193" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#25103e"/>
+      <stop offset="1" stop-color="#0a0015"/>
+    </linearGradient>
+    <linearGradient id="accent-fill" x1="143" y1="47" x2="198" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".45" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <filter id="soft-glow" x="-35%" y="-35%" width="170%" height="170%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feColorMatrix in="blur" values="1 0 0 0 0.75 0 1 0 0 0.25 0 0 1 0 1 0 0 0 0.7 0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <clipPath id="fold-clip">
+      <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z"/>
+    </clipPath>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="#0a0015"/>
+  <path d="M180 44a88 88 0 1 0 0 168" fill="none" stroke="url(#mark-stroke)" stroke-width="18" stroke-linecap="round" filter="url(#soft-glow)"/>
+  <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z" fill="url(#paper-fill)" stroke="url(#mark-stroke)" stroke-width="8" stroke-linejoin="round"/>
+  <g clip-path="url(#fold-clip)">
+    <path d="M151 59v33a10 10 0 0 0 10 10h33z" fill="#120025" stroke="#01cdfe" stroke-width="6" stroke-linejoin="round"/>
+    <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#e8d5f5" stroke-width="9" stroke-linecap="round"/>
+    <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#01cdfe" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  </g>
+  <path d="M146 46 196 20" fill="none" stroke="url(#accent-fill)" stroke-width="16" stroke-linecap="round" filter="url(#soft-glow)"/>
+  <path d="M185 68c16 5 28 16 35 31M196 47c22 8 39 24 49 45" fill="none" stroke="#01cdfe" stroke-width="7" stroke-linecap="round" opacity=".75"/>
+</svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 256" role="img" aria-labelledby="title desc">
+  <title id="title">communiqué logo</title>
+  <desc id="desc">A neon document and signal mark beside the word communiqué.</desc>
+  <defs>
+    <linearGradient id="mark-stroke" x1="42" y1="214" x2="220" y2="28" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".52" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <linearGradient id="paper-fill" x1="82" y1="63" x2="172" y2="193" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#25103e"/>
+      <stop offset="1" stop-color="#0a0015"/>
+    </linearGradient>
+    <linearGradient id="accent-fill" x1="143" y1="47" x2="198" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".45" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <linearGradient id="word-fill" x1="284" y1="82" x2="888" y2="168" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff71ce"/>
+      <stop offset=".47" stop-color="#b967ff"/>
+      <stop offset="1" stop-color="#01cdfe"/>
+    </linearGradient>
+    <filter id="soft-glow" x="-35%" y="-35%" width="170%" height="170%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feColorMatrix in="blur" values="1 0 0 0 0.75 0 1 0 0 0.25 0 0 1 0 1 0 0 0 0.7 0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="word-glow" x="-8%" y="-45%" width="116%" height="190%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feColorMatrix in="blur" values="1 0 0 0 0.73 0 1 0 0 0.4 0 0 1 0 1 0 0 0 0.55 0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <clipPath id="fold-clip">
+      <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z"/>
+    </clipPath>
+  </defs>
+  <rect width="960" height="256" rx="44" fill="#0a0015"/>
+  <g>
+    <path d="M180 44a88 88 0 1 0 0 168" fill="none" stroke="url(#mark-stroke)" stroke-width="18" stroke-linecap="round" filter="url(#soft-glow)"/>
+    <path d="M151 59h5l38 38v87a15 15 0 0 1-15 15H83a15 15 0 0 1-15-15V74a15 15 0 0 1 15-15h68z" fill="url(#paper-fill)" stroke="url(#mark-stroke)" stroke-width="8" stroke-linejoin="round"/>
+    <g clip-path="url(#fold-clip)">
+      <path d="M151 59v33a10 10 0 0 0 10 10h33z" fill="#120025" stroke="#01cdfe" stroke-width="6" stroke-linejoin="round"/>
+      <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#e8d5f5" stroke-width="9" stroke-linecap="round"/>
+      <path d="M91 114h78M91 141h67M91 168h47" fill="none" stroke="#01cdfe" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+    </g>
+    <path d="M146 46 196 20" fill="none" stroke="url(#accent-fill)" stroke-width="16" stroke-linecap="round" filter="url(#soft-glow)"/>
+    <path d="M185 68c16 5 28 16 35 31M196 47c22 8 39 24 49 45" fill="none" stroke="#01cdfe" stroke-width="7" stroke-linecap="round" opacity=".75"/>
+  </g>
+  <g filter="url(#word-glow)">
+    <text x="292" y="145" fill="url(#word-fill)" font-family="Orbitron, Avenir Next, Trebuchet MS, sans-serif" font-size="78" font-weight="800" letter-spacing="2">communiqué</text>
+    <text x="297" y="185" fill="#c9a8e8" font-family="Avenir Next, Trebuchet MS, sans-serif" font-size="22" font-weight="700" letter-spacing="5">RELEASE NOTES FOR HUMANS</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add neon communique logo SVG assets for the docs
- add a dedicated SVG favicon
- wire the logo and favicon into VitePress config

## Tests
- xmllint --noout docs/public/logo-mark.svg docs/public/logo.svg docs/public/favicon.svg
- git diff --check
- npm --prefix docs run docs:build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only static assets and VitePress branding config; no runtime or application logic changes.
> 
> **Overview**
> Adds branded **SVG assets** under `docs/public/`—a square **mark** (`logo-mark.svg`), matching **favicon** (`favicon.svg`), and a wider **wordmark** (`logo.svg` with “communiqué” and tagline)—all using the same neon document / “C” motif and palette aligned with the existing `#b967ff` theme color.
> 
> **VitePress** is updated to use them: a `rel="icon"` link to `/favicon.svg` in `head`, and `themeConfig.logo` set to `/logo-mark.svg` for the site header. The full `logo.svg` is added for reuse elsewhere but is not referenced in config in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8206ea18d008b456d4449e85db903d99a7631e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site’s branding with a new logo in the header.
  * Added an explicit favicon so the site displays the correct icon in browser tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->