### PR TITLE
ci: pin release-plz/action to v0.5.130 tag instead of main

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@1ff444bf83cd861443f5c605c6f523fb18dc4f98 # main
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release
         env:
@@ -152,7 +152,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
         id: release-plz
-        uses: release-plz/action@1ff444bf83cd861443f5c605c6f523fb18dc4f98 # main
+        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Problem

The zizmor security-audit job was failing with exit code 13 on 2 medium [`ref-version-mismatch`](https://docs.zizmor.sh/audits/#ref-version-mismatch) findings in `.github/workflows/release-plz.yml`.

`release-plz/action` was hash-pinned with a `# main` comment. Because `main` is a moving branch, the pinned SHA (`1ff444b`) drifted behind the current branch head (`3e68b2c`), so zizmor's online audit flagged the version comment as mismatched.

This also caused recurring Renovate digest-bump PRs (#210, #213) since it was chasing a branch rather than a release.

## Fix

Pin both usages to the released **v0.5.130** tag (`e8792575c7f2366cf6ff3ccc33ead9ace5b691c7`). The comment is now a stable ref zizmor can verify, and Renovate will track version tags going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to third-party action refs; no application or runtime behavior changes.
> 
> **Overview**
> Pins both `release-plz/action` steps in `release-plz.yml` (release and release-pr jobs) from a hash commented as `# main` to **`v0.5.130`** (`e8792575…`).
> 
> This fixes zizmor **`ref-version-mismatch`** failures where the pinned SHA no longer matched the moving `main` branch, and should stop Renovate from opening digest bumps against a branch head instead of a stable release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10a4409de60c7f3fadccc6ba8e9fd365c69e18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->