### PR TITLE
v1.2.2: Higher Default Token Ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.2](https://github.com/jdx/communique/releases/tag/v1.2.2) - 2026-07-14
+
+## Fixed
+
+- Raise the default per-response token ceiling from 4,096 to 16,384; `--max-tokens` and `[defaults].max_tokens` overrides are unchanged ([#224](https://github.com/jdx/communique/pull/224))
+- Reject token-truncated output and stop substituting changelog content for a missing `release_body`, failing with actionable guidance instead of publishing malformed notes ([#223](https://github.com/jdx/communique/pull/223))
+- Request and validate only the artifacts each output mode needs, letting concise/changelog-only runs submit just a changelog and tailoring retry guidance accordingly ([#225](https://github.com/jdx/communique/pull/225))
+
 ## [1.2.1](https://github.com/jdx/communique/releases/tag/v1.2.1) - 2026-07-07
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.2.1"
+version "1.2.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.1
+**Version**: 1.2.2
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small release focused on making release-note generation reliable for large releases: the default per-response token ceiling is raised, and Communiqué now requests only the artifacts each output mode needs while refusing to publish truncated or substituted notes.

## Fixed

- **Raised default per-response token ceiling from 4,096 to 16,384** — The old 4,096-token default predated Communiqué's structured release-note output and large releases could exhaust it, even though the default Claude Opus 4.8 model supports far larger responses. The new `DEFAULT_MAX_TOKENS` fallback applies only when neither `--max-tokens` nor `[defaults].max_tokens` is set; explicit overrides are unchanged. The `communique init` template, README, and config docs now show `16384` and clarify that billing follows actual model usage, not the configured ceiling. ([#224](https://github.com/jdx/communique/pull/224)) (@jdx)
- **No more truncated or substituted release notes** — Previously, large releases could hit `max_tokens` while producing the `changelog` field, and after repeated malformed submissions Communiqué would "salvage" the run by copying the changelog into `release_body`, publishing a categorized bullet inventory instead of the intended editorial notes. Communiqué now rejects token-truncated output, never substitutes changelog content for a missing `release_body`, and fails with actionable guidance (including a hint to raise `--max-tokens`) rather than publishing bad notes. ([#223](https://github.com/jdx/communique/pull/223)) (@jdx)
- **Generation requests only the artifacts each mode needs** — Detailed (default and `--github-release`) runs no longer spend budget generating an unused changelog, and concise/changelog-only runs can submit just a `changelog` without requiring unused release title/body fields. Retry and max-token guidance is now tailored to the artifacts actually requested, and complete-but-malformed submissions can still be safely coerced even when the model stops at its token limit. ([#225](https://github.com/jdx/communique/pull/225)) (@jdx)

**Full Changelog**: https://github.com/jdx/communique/compare/v1.2.1...HEAD

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime code in the diff.
> 
> **Overview**
> **Release packaging for v1.2.2** — bumps the crate and CLI metadata from `1.2.1` to `1.2.2` in `Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and the generated docs under `docs/cli/`.
> 
> **CHANGELOG** — adds a `[1.2.2]` section (2026-07-14) under **Fixed**, documenting three already-merged changes: default max tokens **4,096 → 16,384** ([#224](https://github.com/jdx/communique/pull/224)), refusal to publish truncated output or substitute changelog for missing `release_body` ([#223](https://github.com/jdx/communique/pull/223)), and mode-specific artifact request/validation ([#225](https://github.com/jdx/communique/pull/225)). The existing **Unreleased** note (default model bump to `claude-opus-4-8`) is unchanged.
> 
> No application source changes appear in this diff; it is version sync and release notes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 172f2d41653b0ad3c48014b9b64621429ec3218f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->