### PR TITLE
fix(agent): prevent truncated release note salvage

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -14,13 +14,17 @@ use crate::tools;
 const MAX_ITERATIONS: usize = 25;
 const MAX_MALFORMED_SUBMISSIONS: usize = 3;
 
-fn parse_submission(input: &serde_json::Value, usage: &Usage) -> Result<ParsedOutput> {
-    let changelog = field_as_string(input, "changelog");
+fn parse_submission(
+    input: &serde_json::Value,
+    usage: &Usage,
+    require_changelog: bool,
+) -> Result<ParsedOutput> {
+    let changelog = require_changelog.then(|| field_as_string(input, "changelog"));
     let release_title = field_as_string(input, "release_title");
     let release_body = field_as_string(input, "release_body");
 
     let mut problems = Vec::new();
-    for res in [&changelog, &release_title, &release_body] {
+    for res in changelog.iter().chain([&release_title, &release_body]) {
         if let Err(Error::Parse(msg)) = res {
             problems.push(msg.clone());
         }
@@ -30,7 +34,7 @@ fn parse_submission(input: &serde_json::Value, usage: &Usage) -> Result<ParsedOu
     }
 
     Ok(ParsedOutput {
-        changelog: changelog.unwrap(),
+        changelog: changelog.transpose()?.unwrap_or_default(),
         release_title: release_title.unwrap(),
         release_body: release_body.unwrap(),
         usage: usage.clone(),
@@ -63,35 +67,21 @@ fn json_type_name(value: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Best-effort parse: coerce non-string fields and derive missing ones from
-/// whatever is available. Returns `None` only when every content-bearing field
-/// is empty or missing.
-fn parse_submission_lenient(input: &serde_json::Value, usage: &Usage) -> Option<ParsedOutput> {
-    let changelog = coerce_to_string(&input["changelog"]);
-    let release_body = coerce_to_string(&input["release_body"]);
-    let release_title = coerce_to_string(&input["release_title"]);
-
-    let primary = release_body
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .or_else(|| {
-            changelog
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-        })?
-        .to_string();
-
-    let changelog = changelog
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| primary.clone());
-    let release_body = release_body
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| primary.clone());
-    let release_title = release_title
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| derive_title(&release_body));
+/// Best-effort parse for models that return the requested fields using the
+/// wrong JSON types. Missing content is never invented: in particular, a
+/// changelog must not silently become the editorial release body.
+fn parse_submission_lenient(
+    input: &serde_json::Value,
+    usage: &Usage,
+    require_changelog: bool,
+) -> Option<ParsedOutput> {
+    let release_body = non_empty_coerced(&input["release_body"])?;
+    let release_title = non_empty_coerced(&input["release_title"])?;
+    let changelog = if require_changelog {
+        non_empty_coerced(&input["changelog"])?
+    } else {
+        String::new()
+    };
 
     Some(ParsedOutput {
         changelog,
@@ -99,6 +89,10 @@ fn parse_submission_lenient(input: &serde_json::Value, usage: &Usage) -> Option<
         release_body,
         usage: usage.clone(),
     })
+}
+
+fn non_empty_coerced(value: &serde_json::Value) -> Option<String> {
+    coerce_to_string(value).filter(|s| !s.trim().is_empty())
 }
 
 fn coerce_to_string(value: &serde_json::Value) -> Option<String> {
@@ -115,17 +109,6 @@ fn coerce_to_string(value: &serde_json::Value) -> Option<String> {
     }
 }
 
-fn derive_title(body: &str) -> String {
-    body.lines()
-        .map(str::trim)
-        .map(|l| l.trim_start_matches('#').trim())
-        .find(|l| !l.is_empty())
-        .unwrap_or("Release")
-        .chars()
-        .take(80)
-        .collect()
-}
-
 pub struct AgentContext<'a> {
     pub client: &'a dyn LlmClient,
     pub system: &'a str,
@@ -134,6 +117,7 @@ pub struct AgentContext<'a> {
     pub repo_root: &'a Path,
     pub github: Option<&'a GitHubClient>,
     pub verify_links: bool,
+    pub require_changelog: bool,
     pub job: &'a Arc<ProgressJob>,
 }
 
@@ -146,6 +130,7 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         repo_root,
         github,
         verify_links,
+        require_changelog,
         job,
     } = ctx;
 
@@ -178,15 +163,17 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         let mut malformed_submit = Vec::new();
         for tc in &response.tool_calls {
             if tc.name == "submit_release_notes" {
-                match parse_submission(&tc.input, &total_usage) {
+                match parse_submission(&tc.input, &total_usage, require_changelog) {
                     Ok(parsed) => submit = Some((tc.id.clone(), parsed)),
                     Err(Error::Parse(message)) => {
                         malformed_reasons.push(message.clone());
                         last_malformed_input = Some(tc.input.clone());
                         malformed_submit.push(ToolResult {
                             tool_call_id: tc.id.clone(),
-                            content: format!(
-                                "Error: {message}\n\nPlease call submit_release_notes again with non-empty string values for all three required fields: changelog, release_title, and release_body."
+                            content: submission_retry_message(
+                                &message,
+                                &response.stop_reason,
+                                require_changelog,
                             ),
                             is_error: true,
                         });
@@ -231,8 +218,10 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
                     .as_ref()
                     .and_then(|v| serde_json::to_string_pretty(v).ok())
                     .unwrap_or_else(|| "<no input captured>".into());
-                if let Some(input) = &last_malformed_input
-                    && let Some(parsed) = parse_submission_lenient(input, &total_usage)
+                if response.stop_reason != StopReason::MaxTokens
+                    && let Some(input) = &last_malformed_input
+                    && let Some(parsed) =
+                        parse_submission_lenient(input, &total_usage, require_changelog)
                 {
                     log::warn!(
                         "submit_release_notes was malformed {malformed_submission_count} times ({}); salvaging the last attempt. Received input:\n{received}",
@@ -250,6 +239,12 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
             }
             client.append_tool_results(&mut conversation, &malformed_submit);
             continue;
+        }
+
+        if response.stop_reason == StopReason::MaxTokens {
+            return Err(Error::Llm(
+                "model response reached max_tokens before completing release notes; increase --max-tokens or defaults.max_tokens".into(),
+            ));
         }
 
         if response.tool_calls.is_empty() || response.stop_reason == StopReason::EndTurn {
@@ -364,6 +359,27 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
     )))
 }
 
+fn submission_retry_message(
+    message: &str,
+    stop_reason: &StopReason,
+    require_changelog: bool,
+) -> String {
+    let fields = if require_changelog {
+        "release_title, release_body, and changelog"
+    } else {
+        "release_title and release_body"
+    };
+    if *stop_reason == StopReason::MaxTokens {
+        format!(
+            "Error: the response reached max_tokens before the submission was complete ({message}).\n\nCall submit_release_notes again with non-empty string values for {fields}. Keep the response within the available budget: prioritize a complete editorial release_body, group related changes, and omit minor or internal details. Do not repeat an oversized changelog."
+        )
+    } else {
+        format!(
+            "Error: {message}\n\nPlease call submit_release_notes again with non-empty string values for {fields}."
+        )
+    }
+}
+
 fn tool_detail(name: &str, input: &serde_json::Value) -> String {
     match name {
         "read_file" => {
@@ -413,24 +429,34 @@ mod tests {
     }
 
     #[test]
-    fn test_lenient_empty_release_body_falls_back_to_changelog() {
-        // Regression: `coerce_to_string` returned Some("") for `[""]`, which
-        // used to short-circuit the `.or(changelog)` fallback.
+    fn test_detailed_only_submission_does_not_require_changelog() {
         let input = json!({
-            "release_body": [""],
-            "changelog": "- Fixed X",
+            "release_title": "A useful title",
+            "release_body": "A useful editorial body",
         });
-        let result = parse_submission_lenient(&input, &fake_usage()).unwrap();
-        assert_eq!(result.changelog, "- Fixed X");
-        assert_eq!(result.release_body, "- Fixed X");
+        let result = parse_submission(&input, &fake_usage(), false).unwrap();
+        assert!(result.changelog.is_empty());
+        assert_eq!(result.release_title, "A useful title");
+        assert_eq!(result.release_body, "A useful editorial body");
     }
 
     #[test]
-    fn test_derive_title_skips_empty_after_stripping_markers() {
-        assert_eq!(derive_title("###\n\nReal title here"), "Real title here");
-        assert_eq!(derive_title("#   \nActual content"), "Actual content");
-        assert_eq!(derive_title(""), "Release");
-        assert_eq!(derive_title("\n\n   \n"), "Release");
+    fn test_max_tokens_retry_prioritizes_editorial_body() {
+        let message =
+            submission_retry_message("missing `release_body`", &StopReason::MaxTokens, true);
+        assert!(message.contains("reached max_tokens"));
+        assert!(message.contains("prioritize a complete editorial release_body"));
+        assert!(message.contains("Do not repeat an oversized changelog"));
+    }
+
+    #[test]
+    fn test_lenient_missing_release_body_is_not_salvaged() {
+        let input = json!({
+            "release_body": [""],
+            "changelog": "- Fixed X",
+            "release_title": "Fix X",
+        });
+        assert!(parse_submission_lenient(&input, &fake_usage(), true).is_none());
     }
 
     #[tokio::test]
@@ -451,6 +477,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -489,6 +516,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -515,6 +543,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let err = run(ctx).await.unwrap_err();
@@ -540,6 +569,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -565,10 +595,37 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let err = run(ctx).await.unwrap_err();
         assert!(matches!(err, Error::Llm(_)));
+    }
+
+    #[tokio::test]
+    async fn test_max_tokens_text_is_not_published_as_release_notes() {
+        let client = MockLlmClient::new(vec![TurnResponse {
+            tool_calls: vec![],
+            text: Some("# Partial title\n\nTruncated body".into()),
+            stop_reason: StopReason::MaxTokens,
+            usage: fake_usage(),
+        }]);
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        let tmp = std::env::temp_dir();
+        let ctx = AgentContext {
+            client: &client,
+            system: "",
+            user_message: "",
+            tool_defs: vec![],
+            repo_root: &tmp,
+            github: None,
+            verify_links: false,
+            require_changelog: false,
+            job: &job,
+        };
+        let err = run(ctx).await.unwrap_err();
+        assert!(matches!(err, Error::Llm(_)));
+        assert!(err.to_string().contains("reached max_tokens"));
     }
 
     #[tokio::test]
@@ -604,6 +661,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -645,6 +703,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -686,6 +745,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -695,10 +755,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_malformed_submission_salvages_partial() {
-        // Model submits changelog + release_title but never release_body across
-        // three attempts. Rather than failing, we salvage the partial submission
-        // by deriving release_body from changelog.
+    async fn test_malformed_submission_does_not_replace_body_with_changelog() {
+        // A changelog is not a safe substitute for editorial release notes.
         let partial = |id: &str| ToolCall {
             id: id.into(),
             name: "submit_release_notes".into(),
@@ -737,12 +795,11 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
-        let result = run(ctx).await.unwrap();
-        assert_eq!(result.changelog, "- Added X\n- Fixed Y");
-        assert_eq!(result.release_title, "v1.0");
-        assert_eq!(result.release_body, "- Added X\n- Fixed Y");
+        let err = run(ctx).await.unwrap_err();
+        assert!(matches!(err, Error::MalformedSubmission { .. }));
     }
 
     #[tokio::test]
@@ -784,6 +841,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let err = run(ctx).await.unwrap_err();
@@ -801,7 +859,7 @@ mod tests {
             assert!(reasons.contains("changelog"), "reasons: {reasons}");
             assert!(reasons.contains("release_title"), "reasons: {reasons}");
             assert!(reasons.contains("release_body"), "reasons: {reasons}");
-            assert!(span.len() > 0, "span should point into source");
+            assert!(!span.is_empty(), "span should point into source");
         }
     }
 
@@ -811,7 +869,7 @@ mod tests {
         // error. With {} input, only `changelog` was reported, which made the
         // diagnostic list three identical lines instead of all three missing
         // fields.
-        let err = parse_submission(&json!({}), &fake_usage()).unwrap_err();
+        let err = parse_submission(&json!({}), &fake_usage(), true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("changelog"), "msg: {msg}");
         assert!(msg.contains("release_title"), "msg: {msg}");
@@ -861,6 +919,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -902,6 +961,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: true,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -952,6 +1012,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: true,
+            require_changelog: true,
             job: &job,
         };
         let result = run(ctx).await.unwrap();
@@ -983,6 +1044,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_changelog: true,
             job: &job,
         };
         let err = run(ctx).await.unwrap_err();

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     #[diagnostic(
         code(communique::malformed_submission),
         help(
-            "The model could not produce a valid submit_release_notes tool call. Problems:\n  - {reasons}\n\nCheck that the model is producing non-empty string values for all three required fields: changelog, release_title, release_body."
+            "The model could not produce a valid submit_release_notes tool call. Problems:\n  - {reasons}\n\nCheck that the model is producing non-empty string values for every field requested by the submit_release_notes schema. If the response reached max_tokens, increase --max-tokens or defaults.max_tokens."
         )
     )]
     MalformedSubmission {

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -109,7 +109,8 @@ pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
         .start();
 
     let ctx = gather_context(&opts, &job).await?;
-    let mut parsed = generate_notes(&ctx, opts.dry_run, &job).await?;
+    let include_changelog = opts.changelog || opts.concise;
+    let mut parsed = generate_notes(&ctx, opts.dry_run, include_changelog, &job).await?;
 
     // Normalize release title to "label: description" format.
     // The LLM may include the tag with a different separator (e.g. "v1.0.0 (title)"
@@ -238,6 +239,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
 async fn generate_notes(
     ctx: &Context,
     dry_run: bool,
+    include_changelog: bool,
     job: &Arc<ProgressJob>,
 ) -> miette::Result<ParsedOutput> {
     let git_log = git::log_between(&ctx.repo_root, &ctx.prev_tag, &ctx.tag)?;
@@ -300,7 +302,7 @@ async fn generate_notes(
     };
 
     let emoji = ctx.defaults.emoji.unwrap_or(true);
-    let system = prompt::system_prompt(ctx.system_extra.as_deref(), emoji);
+    let system = prompt::system_prompt(ctx.system_extra.as_deref(), emoji, include_changelog);
     let user_msg = prompt::user_prompt(&prompt::UserPromptContext {
         tag: &ctx.tag,
         prev_tag: &ctx.prev_tag,
@@ -315,7 +317,7 @@ async fn generate_notes(
     });
 
     job.prop("message", "Generating release notes...");
-    let tool_defs = tools::all_definitions(ctx.github_client.is_some());
+    let tool_defs = tools::all_definitions(ctx.github_client.is_some(), include_changelog);
 
     let verify_links = !dry_run && ctx.defaults.verify_links.unwrap_or(true);
 
@@ -327,6 +329,7 @@ async fn generate_notes(
         repo_root: &ctx.repo_root,
         github: ctx.github_client.as_ref(),
         verify_links,
+        require_changelog: include_changelog,
         job,
     })
     .await
@@ -524,7 +527,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "Initial Release");
         assert!(parsed.changelog.contains("Main function"));
     }
@@ -583,7 +586,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "Title");
         assert_eq!(parsed.release_body, "Body");
     }
@@ -866,7 +869,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0");
         assert!(parsed.release_body.contains("main entry point"));
     }
@@ -948,7 +951,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0");
         assert!(parsed.release_body.contains("greeting"));
     }
@@ -1085,7 +1088,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0 - Feature Release");
         assert!(parsed.changelog.contains("feature"));
     }
@@ -1164,7 +1167,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         publish(&opts, &ctx, &parsed, &job).await.unwrap();
         // wiremock expect(1) verifies PATCH was called
     }
@@ -1220,7 +1223,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
         assert_eq!(parsed.usage.input_tokens, 250);
         assert_eq!(parsed.usage.output_tokens, 125);
     }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,4 +1,4 @@
-pub fn system_prompt(extra: Option<&str>, emoji: bool) -> String {
+pub fn system_prompt(extra: Option<&str>, emoji: bool, include_changelog: bool) -> String {
     let mut prompt = r#"You are an expert technical writer generating release notes for a software project.
 
 You have access to tools to browse the repository:
@@ -13,10 +13,7 @@ You have access to tools to browse the repository:
 
 Use these tools to understand what changed and why. Read relevant source files, PR descriptions, and diffs to write accurate, insightful release notes.
 
-When you are done researching, call the `submit_release_notes` tool with three fields:
-
-### `changelog`
-A concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized bullet points. Reference relevant PRs, issues, and commits as markdown links — e.g. `[#123](https://github.com/OWNER/REPO/pull/123)` for PRs/issues or `[abc1234](https://github.com/OWNER/REPO/commit/abc1234)` for commits.
+When you are done researching, call the `submit_release_notes` tool with the requested fields.
 
 ### `release_title`
 A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as "vX.Y.Z: your title").
@@ -64,6 +61,15 @@ Write clearly and concisely. Focus on what matters to END USERS of the software.
 IMPORTANT: Only include changes that affect end users. Omit purely internal changes such as CI/CD pipeline updates, linter configurations, pre-commit hooks, build caching, code formatting, internal refactors, dependency updates (unless they fix a user-facing bug or add a user-facing feature), and dev tooling changes. If a release has no user-facing changes, say so briefly rather than padding the notes with internal details.
 
 Be honest about the scope of a release. If it only has one or two user-facing changes, say that — don't inflate it into something bigger than it is. A short, accurate release note is always better than a long, padded one."#.to_string();
+
+    if include_changelog {
+        prompt.push_str(
+            r#"
+
+### `changelog`
+A concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized bullet points. Reference relevant PRs, issues, and commits as markdown links — e.g. `[#123](https://github.com/OWNER/REPO/pull/123)` for PRs/issues or `[abc1234](https://github.com/OWNER/REPO/commit/abc1234)` for commits. Keep this substantially shorter than `release_body`; group related changes and omit minor or internal work so both artifacts fit in one response."#,
+        );
+    }
 
     if !emoji {
         prompt.push_str("\n\nDo NOT use emoji anywhere in the output — not in headings, titles, bullet points, or prose.");
@@ -180,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_system_prompt_default() {
-        let prompt = system_prompt(None, true);
+        let prompt = system_prompt(None, true, true);
         assert!(prompt.contains("submit_release_notes"));
         assert!(prompt.contains("Keep a Changelog"));
         assert!(prompt.contains("10+ distinct user-facing changes"));
@@ -193,14 +199,21 @@ mod tests {
 
     #[test]
     fn test_system_prompt_no_emoji() {
-        let prompt = system_prompt(None, false);
+        let prompt = system_prompt(None, false, true);
         assert!(prompt.contains("Do NOT use emoji"));
     }
 
     #[test]
     fn test_system_prompt_with_extra() {
-        let prompt = system_prompt(Some("Always mention cats"), true);
+        let prompt = system_prompt(Some("Always mention cats"), true, true);
         assert!(prompt.contains("Always mention cats"));
+    }
+
+    #[test]
+    fn test_system_prompt_detailed_only_omits_changelog_request() {
+        let prompt = system_prompt(None, true, false);
+        assert!(!prompt.contains("### `changelog`"));
+        assert!(prompt.contains("### `release_body`"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -44,14 +44,14 @@ impl ToolCache {
     }
 }
 
-pub fn all_definitions(has_github: bool) -> Vec<ToolDefinition> {
+pub fn all_definitions(has_github: bool, include_changelog: bool) -> Vec<ToolDefinition> {
     let mut defs = vec![
         read_file::definition(),
         list_files::definition(),
         grep::definition(),
         git_show::definition(),
         get_commits::definition(),
-        submit_release_notes::definition(),
+        submit_release_notes::definition(include_changelog),
     ];
     if has_github {
         defs.push(get_pr::definition());
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_all_definitions_without_github() {
-        let defs = all_definitions(false);
+        let defs = all_definitions(false, false);
         assert_eq!(defs.len(), 6);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"read_file"));
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_all_definitions_with_github() {
-        let defs = all_definitions(true);
+        let defs = all_definitions(true, true);
         assert_eq!(defs.len(), 9);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"get_pr"));

--- a/src/tools/submit_release_notes.rs
+++ b/src/tools/submit_release_notes.rs
@@ -2,27 +2,58 @@ use serde_json::json;
 
 use crate::llm::ToolDefinition;
 
-pub fn definition() -> ToolDefinition {
+pub fn definition(include_changelog: bool) -> ToolDefinition {
+    let mut properties = json!({
+        "release_title": {
+            "type": "string",
+            "description": "A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as 'vX.Y.Z: your title')."
+        },
+        "release_body": {
+            "type": "string",
+            "description": "Detailed GitHub release notes in markdown. Follow the template from the system prompt: narrative summary, optional Highlights only for broad releases where they synthesize themes instead of duplicating categorized bullets, categorized sections (Added, Fixed, Changed, etc.), optional Breaking Changes, optional New Contributors, and a Full Changelog link."
+        }
+    });
+    let mut required = vec!["release_title", "release_body"];
+    if include_changelog {
+        properties["changelog"] = json!({
+            "type": "string",
+            "description": "Concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized items. Keep this substantially shorter than the detailed release body."
+        });
+        required.push("changelog");
+    }
+
     ToolDefinition {
         name: "submit_release_notes".into(),
         description: "Submit the final release notes. Call this exactly once when you are done researching and are ready to deliver the release notes.".into(),
         input_schema: json!({
             "type": "object",
-            "properties": {
-                "changelog": {
-                    "type": "string",
-                    "description": "Concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized items."
-                },
-                "release_title": {
-                    "type": "string",
-                    "description": "A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as 'vX.Y.Z: your title')."
-                },
-                "release_body": {
-                    "type": "string",
-                    "description": "Detailed GitHub release notes in markdown. Follow the template from the system prompt: narrative summary, optional Highlights only for broad releases where they synthesize themes instead of duplicating categorized bullets, categorized sections (Added, Fixed, Changed, etc.), optional Breaking Changes, optional New Contributors, and a Full Changelog link."
-                }
-            },
-            "required": ["changelog", "release_title", "release_body"]
+            "properties": properties,
+            "required": required
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detailed_only_schema_omits_changelog() {
+        let definition = definition(false);
+        assert!(definition.input_schema["properties"]["changelog"].is_null());
+        assert_eq!(
+            definition.input_schema["required"],
+            json!(["release_title", "release_body"])
+        );
+    }
+
+    #[test]
+    fn combined_schema_requires_changelog() {
+        let definition = definition(true);
+        assert!(definition.input_schema["properties"]["changelog"].is_object());
+        assert_eq!(
+            definition.input_schema["required"],
+            json!(["release_title", "release_body", "changelog"])
+        );
     }
 }


### PR DESCRIPTION
## Summary

- request a changelog only when `--concise` or `--changelog` needs one, leaving the response budget available for editorial notes in normal and `--github-release` runs
- give the model focused retry guidance when a submission reaches `max_tokens`
- reject token-truncated text fallbacks and never substitute changelog content for a missing `release_body`
- keep lenient coercion for complete submissions that use the wrong JSON types

## Root cause

Large releases could exhaust the response budget while producing the `changelog` field. After three incomplete `submit_release_notes` calls, Communiqué treated the malformed result as successful and copied that changelog into `release_body`. Callers then published a categorized inventory instead of the intended editorial notes.

## Impact

Detailed-note runs no longer spend tokens generating an unused second artifact. If generation still reaches its limit, Communiqué asks for a compact complete retry and ultimately fails rather than publishing truncated or substituted notes.

## Validation

- `cargo +1.95.0 test` (172 unit tests, 4 integration tests)
- `RUSTUP_TOOLCHAIN=1.95.0 mise run lint`
- `cargo +1.95.0 fmt --check`
- `git diff --check`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM output validation and publish paths for release notes; behavior shifts from salvage-on-failure to fail-fast on truncation, which is safer but may surface more user-visible errors on token-limited runs.
> 
> **Overview**
> Fixes a failure mode where large releases could hit **max_tokens** while building `changelog`, then after repeated malformed `submit_release_notes` calls Communiqué **salvaged** by copying changelog into `release_body` and publishing a bullet inventory instead of editorial notes.
> 
> **Conditional changelog:** `include_changelog` is only true when `--changelog` or `--concise` is set. The system prompt, `submit_release_notes` schema, and agent `require_changelog` flag align so default / `--github-release` runs only ask for `release_title` and `release_body`, leaving token budget for the editorial body.
> 
> **Stricter submission handling:** Lenient salvage no longer invents missing fields (no changelog→body fallback, no `derive_title`). Salvage after three malformed attempts is skipped when `stop_reason` is `MaxTokens`. Truncated turns error explicitly instead of using text fallback. Retry messages call out max-token cases and tell the model to prioritize a complete `release_body`.
> 
> **Diagnostics:** `MalformedSubmission` help text references the dynamic schema and suggests raising `--max-tokens` when truncation is involved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aca0339d2388a3e9d10798ac0e20248c67f086b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->