### PR TITLE
fix(config): raise default response token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Avoid marketing language.
 [defaults]
 model = "claude-opus-4-8"
 repo = "owner/repo"
-max_tokens = 4096
+max_tokens = 16384
 ```
 
 CLI flags override config defaults.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -37,14 +37,14 @@ Default parameters for generation. All values can be overridden via CLI flags.
 ```toml
 [defaults]
 model = "claude-opus-4-8"
-max_tokens = 4096
+max_tokens = 16384
 repo = "owner/repo"
 ```
 
 | Key | Description | Default |
 |-----|-------------|---------|
 | `model` | Model identifier | `claude-opus-4-8` |
-| `max_tokens` | Maximum response tokens | `4096` |
+| `max_tokens` | Maximum tokens permitted per model response (billing is based on actual usage) | `16384` |
 | `repo` | GitHub repo in `owner/repo` format | Auto-detected from git remote |
 
 ## Resolution Order

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::error::Result;
+
+pub const DEFAULT_MAX_TOKENS: u32 = 16_384;
 use crate::providers::Provider;
 
 #[derive(Debug, Deserialize, Default)]
@@ -34,7 +36,7 @@ const TEMPLATE: &str = r#"# Extra instructions appended to the system prompt.
 
 [defaults]
 #model = "claude-opus-4-8"
-#max_tokens = 4096
+#max_tokens = 16384
 #repo = "owner/repo"
 #provider = "anthropic"
 #base_url = ""
@@ -137,6 +139,7 @@ emoji = false
     fn test_template_is_valid_toml() {
         let config: Config = toml::from_str(Config::template()).unwrap();
         assert!(config.system_extra.is_none());
+        assert!(Config::template().contains("#max_tokens = 16384"));
     }
 
     #[test]

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -174,7 +174,10 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
         .clone()
         .or(defaults.model.clone())
         .unwrap_or_else(|| "claude-opus-4-8".into());
-    let max_tokens = opts.max_tokens.or(defaults.max_tokens).unwrap_or(4096);
+    let max_tokens = opts
+        .max_tokens
+        .or(defaults.max_tokens)
+        .unwrap_or(config::DEFAULT_MAX_TOKENS);
     let owner_repo = match opts.repo.clone().or(defaults.repo.clone()) {
         Some(r) => r,
         None => git::detect_remote(&repo_root)?,


### PR DESCRIPTION
## Summary

- raise the default per-response token ceiling from 4,096 to 16,384
- keep `--max-tokens` and `[defaults].max_tokens` overrides unchanged
- update the generated config template and user documentation
- clarify that billing is based on actual model usage, not the configured ceiling

## Why

The 4,096-token default came from Communiqué's initial implementation and no longer matches the size of its structured release-note output. Large releases can exhaust that ceiling even though the default Claude Opus 4.8 model supports substantially larger responses. A 16,384-token ceiling leaves enough room for editorial notes without reserving or automatically billing the full amount.

This is intentionally separate from #223, which prevents malformed or token-truncated output from being silently published.

## Validation

- `cargo +1.95.0 test` (167 unit tests, 4 integration tests)
- `RUSTUP_TOOLCHAIN=1.95.0 mise run lint`
- `cargo +1.95.0 fmt --check`
- `git diff --check`

*This pull request was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and documentation default only; CLI and `communique.toml` overrides behave as before.
> 
> **Overview**
> Raises the built-in **per-response token ceiling** from **4,096** to **16,384** so large release-note generations are less likely to hit the limit. The fallback is centralized as `DEFAULT_MAX_TOKENS` in `config.rs`, and `generate` uses it when neither `--max-tokens` nor `[defaults].max_tokens` is set.
> 
> **`communique init` template**, **README**, and **configuration docs** now show `16384`; the docs also note that **billing follows actual usage**, not the configured maximum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591dede154d2bf7a3a649a13673ec088e1ad656f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->