### PR TITLE
fix(agent): honor requested release artifacts

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -17,14 +17,19 @@ const MAX_MALFORMED_SUBMISSIONS: usize = 3;
 fn parse_submission(
     input: &serde_json::Value,
     usage: &Usage,
+    require_release_notes: bool,
     require_changelog: bool,
 ) -> Result<ParsedOutput> {
     let changelog = require_changelog.then(|| field_as_string(input, "changelog"));
-    let release_title = field_as_string(input, "release_title");
-    let release_body = field_as_string(input, "release_body");
+    let release_title = require_release_notes.then(|| field_as_string(input, "release_title"));
+    let release_body = require_release_notes.then(|| field_as_string(input, "release_body"));
 
     let mut problems = Vec::new();
-    for res in changelog.iter().chain([&release_title, &release_body]) {
+    for res in changelog
+        .iter()
+        .chain(release_title.iter())
+        .chain(release_body.iter())
+    {
         if let Err(Error::Parse(msg)) = res {
             problems.push(msg.clone());
         }
@@ -35,8 +40,8 @@ fn parse_submission(
 
     Ok(ParsedOutput {
         changelog: changelog.transpose()?.unwrap_or_default(),
-        release_title: release_title.unwrap(),
-        release_body: release_body.unwrap(),
+        release_title: release_title.transpose()?.unwrap_or_default(),
+        release_body: release_body.transpose()?.unwrap_or_default(),
         usage: usage.clone(),
     })
 }
@@ -73,10 +78,17 @@ fn json_type_name(value: &serde_json::Value) -> &'static str {
 fn parse_submission_lenient(
     input: &serde_json::Value,
     usage: &Usage,
+    require_release_notes: bool,
     require_changelog: bool,
 ) -> Option<ParsedOutput> {
-    let release_body = non_empty_coerced(&input["release_body"])?;
-    let release_title = non_empty_coerced(&input["release_title"])?;
+    let (release_title, release_body) = if require_release_notes {
+        (
+            non_empty_coerced(&input["release_title"])?,
+            non_empty_coerced(&input["release_body"])?,
+        )
+    } else {
+        (String::new(), String::new())
+    };
     let changelog = if require_changelog {
         non_empty_coerced(&input["changelog"])?
     } else {
@@ -117,6 +129,7 @@ pub struct AgentContext<'a> {
     pub repo_root: &'a Path,
     pub github: Option<&'a GitHubClient>,
     pub verify_links: bool,
+    pub require_release_notes: bool,
     pub require_changelog: bool,
     pub job: &'a Arc<ProgressJob>,
 }
@@ -130,6 +143,7 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         repo_root,
         github,
         verify_links,
+        require_release_notes,
         require_changelog,
         job,
     } = ctx;
@@ -163,7 +177,12 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
         let mut malformed_submit = Vec::new();
         for tc in &response.tool_calls {
             if tc.name == "submit_release_notes" {
-                match parse_submission(&tc.input, &total_usage, require_changelog) {
+                match parse_submission(
+                    &tc.input,
+                    &total_usage,
+                    require_release_notes,
+                    require_changelog,
+                ) {
                     Ok(parsed) => submit = Some((tc.id.clone(), parsed)),
                     Err(Error::Parse(message)) => {
                         malformed_reasons.push(message.clone());
@@ -173,6 +192,7 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
                             content: submission_retry_message(
                                 &message,
                                 &response.stop_reason,
+                                require_release_notes,
                                 require_changelog,
                             ),
                             is_error: true,
@@ -218,10 +238,13 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
                     .as_ref()
                     .and_then(|v| serde_json::to_string_pretty(v).ok())
                     .unwrap_or_else(|| "<no input captured>".into());
-                if response.stop_reason != StopReason::MaxTokens
-                    && let Some(input) = &last_malformed_input
-                    && let Some(parsed) =
-                        parse_submission_lenient(input, &total_usage, require_changelog)
+                if let Some(input) = &last_malformed_input
+                    && let Some(parsed) = parse_submission_lenient(
+                        input,
+                        &total_usage,
+                        require_release_notes,
+                        require_changelog,
+                    )
                 {
                     log::warn!(
                         "submit_release_notes was malformed {malformed_submission_count} times ({}); salvaging the last attempt. Received input:\n{received}",
@@ -362,16 +385,30 @@ pub async fn run(ctx: AgentContext<'_>) -> Result<ParsedOutput> {
 fn submission_retry_message(
     message: &str,
     stop_reason: &StopReason,
+    require_release_notes: bool,
     require_changelog: bool,
 ) -> String {
-    let fields = if require_changelog {
-        "release_title, release_body, and changelog"
-    } else {
-        "release_title and release_body"
+    let fields = match (require_release_notes, require_changelog) {
+        (true, true) => "release_title, release_body, and changelog",
+        (true, false) => "release_title and release_body",
+        (false, true) => "changelog",
+        (false, false) => unreachable!("at least one output must be required"),
     };
     if *stop_reason == StopReason::MaxTokens {
+        let budget_hint = match (require_release_notes, require_changelog) {
+            (true, true) => {
+                "prioritize a complete editorial release_body, group related changes, omit minor or internal details, and do not repeat an oversized changelog"
+            }
+            (true, false) => {
+                "prioritize a complete editorial release_body, group related changes, and omit minor or internal details"
+            }
+            (false, true) => {
+                "produce a concise grouped changelog and omit minor or internal details"
+            }
+            (false, false) => unreachable!("at least one output must be required"),
+        };
         format!(
-            "Error: the response reached max_tokens before the submission was complete ({message}).\n\nCall submit_release_notes again with non-empty string values for {fields}. Keep the response within the available budget: prioritize a complete editorial release_body, group related changes, and omit minor or internal details. Do not repeat an oversized changelog."
+            "Error: the response reached max_tokens before the submission was complete ({message}).\n\nCall submit_release_notes again with non-empty string values for {fields}. Keep the response within the available budget: {budget_hint}."
         )
     } else {
         format!(
@@ -434,19 +471,45 @@ mod tests {
             "release_title": "A useful title",
             "release_body": "A useful editorial body",
         });
-        let result = parse_submission(&input, &fake_usage(), false).unwrap();
+        let result = parse_submission(&input, &fake_usage(), true, false).unwrap();
         assert!(result.changelog.is_empty());
         assert_eq!(result.release_title, "A useful title");
         assert_eq!(result.release_body, "A useful editorial body");
     }
 
     #[test]
+    fn test_changelog_only_submission_does_not_require_release_notes() {
+        let input = json!({ "changelog": "## Fixed\n- A useful fix" });
+        let result = parse_submission(&input, &fake_usage(), false, true).unwrap();
+        assert_eq!(result.changelog, "## Fixed\n- A useful fix");
+        assert!(result.release_title.is_empty());
+        assert!(result.release_body.is_empty());
+    }
+
+    #[test]
     fn test_max_tokens_retry_prioritizes_editorial_body() {
         let message =
-            submission_retry_message("missing `release_body`", &StopReason::MaxTokens, true);
+            submission_retry_message("missing `release_body`", &StopReason::MaxTokens, true, true);
         assert!(message.contains("reached max_tokens"));
         assert!(message.contains("prioritize a complete editorial release_body"));
-        assert!(message.contains("Do not repeat an oversized changelog"));
+        assert!(message.contains("do not repeat an oversized changelog"));
+    }
+
+    #[test]
+    fn test_max_tokens_retry_matches_requested_artifacts() {
+        let release_only = submission_retry_message(
+            "missing `release_body`",
+            &StopReason::MaxTokens,
+            true,
+            false,
+        );
+        assert!(release_only.contains("release_title and release_body"));
+        assert!(!release_only.contains("changelog"));
+
+        let changelog_only =
+            submission_retry_message("missing `changelog`", &StopReason::MaxTokens, false, true);
+        assert!(changelog_only.contains("concise grouped changelog"));
+        assert!(!changelog_only.contains("release_body"));
     }
 
     #[test]
@@ -456,7 +519,7 @@ mod tests {
             "changelog": "- Fixed X",
             "release_title": "Fix X",
         });
-        assert!(parse_submission_lenient(&input, &fake_usage(), true).is_none());
+        assert!(parse_submission_lenient(&input, &fake_usage(), true, true).is_none());
     }
 
     #[tokio::test]
@@ -477,6 +540,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -484,6 +548,38 @@ mod tests {
         assert_eq!(result.changelog, "log");
         assert_eq!(result.release_title, "v1.0");
         assert_eq!(result.release_body, "body");
+    }
+
+    #[tokio::test]
+    async fn test_changelog_only_direct_submission() {
+        let client = MockLlmClient::new(vec![TurnResponse {
+            tool_calls: vec![ToolCall {
+                id: "call_1".into(),
+                name: "submit_release_notes".into(),
+                input: json!({ "changelog": "## Fixed\n- A useful fix" }),
+            }],
+            text: None,
+            stop_reason: StopReason::ToolUse,
+            usage: fake_usage(),
+        }]);
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        let tmp = std::env::temp_dir();
+        let ctx = AgentContext {
+            client: &client,
+            system: "",
+            user_message: "",
+            tool_defs: vec![],
+            repo_root: &tmp,
+            github: None,
+            verify_links: false,
+            require_release_notes: false,
+            require_changelog: true,
+            job: &job,
+        };
+        let result = run(ctx).await.unwrap();
+        assert_eq!(result.changelog, "## Fixed\n- A useful fix");
+        assert!(result.release_title.is_empty());
+        assert!(result.release_body.is_empty());
     }
 
     #[tokio::test]
@@ -516,6 +612,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -543,6 +640,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -569,6 +667,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -595,6 +694,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -620,6 +720,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: false,
             job: &job,
         };
@@ -661,6 +762,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -703,6 +805,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -745,6 +848,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -781,7 +885,7 @@ mod tests {
             TurnResponse {
                 tool_calls: vec![partial("call_3")],
                 text: None,
-                stop_reason: StopReason::ToolUse,
+                stop_reason: StopReason::MaxTokens,
                 usage: fake_usage(),
             },
         ]);
@@ -795,6 +899,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -841,6 +946,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -869,7 +975,7 @@ mod tests {
         // error. With {} input, only `changelog` was reported, which made the
         // diagnostic list three identical lines instead of all three missing
         // fields.
-        let err = parse_submission(&json!({}), &fake_usage(), true).unwrap_err();
+        let err = parse_submission(&json!({}), &fake_usage(), true, true).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("changelog"), "msg: {msg}");
         assert!(msg.contains("release_title"), "msg: {msg}");
@@ -905,7 +1011,7 @@ mod tests {
             TurnResponse {
                 tool_calls: vec![make("c3")],
                 text: None,
-                stop_reason: StopReason::ToolUse,
+                stop_reason: StopReason::MaxTokens,
                 usage: fake_usage(),
             },
         ]);
@@ -919,6 +1025,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -961,6 +1068,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: true,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -1012,6 +1120,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: true,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };
@@ -1044,6 +1153,7 @@ mod tests {
             repo_root: &tmp,
             github: None,
             verify_links: false,
+            require_release_notes: true,
             require_changelog: true,
             job: &job,
         };

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -110,13 +110,23 @@ pub async fn run(opts: GenerateOptions) -> miette::Result<()> {
 
     let ctx = gather_context(&opts, &job).await?;
     let include_changelog = opts.changelog || opts.concise;
-    let mut parsed = generate_notes(&ctx, opts.dry_run, include_changelog, &job).await?;
+    let include_release_notes = opts.github_release || !opts.concise;
+    let mut parsed = generate_notes(
+        &ctx,
+        opts.dry_run,
+        include_release_notes,
+        include_changelog,
+        &job,
+    )
+    .await?;
 
     // Normalize release title to "label: description" format.
     // The LLM may include the tag with a different separator (e.g. "v1.0.0 (title)"
     // or "v1.0.0 - title"), so we check for the exact "label: " prefix.
-    let display_tag = ctx.display_tag();
-    parsed.release_title = normalize_release_title(parsed.release_title, display_tag, &ctx.tag);
+    if include_release_notes {
+        let display_tag = ctx.display_tag();
+        parsed.release_title = normalize_release_title(parsed.release_title, display_tag, &ctx.tag);
+    }
 
     publish(&opts, &ctx, &parsed, &job).await?;
 
@@ -242,6 +252,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
 async fn generate_notes(
     ctx: &Context,
     dry_run: bool,
+    include_release_notes: bool,
     include_changelog: bool,
     job: &Arc<ProgressJob>,
 ) -> miette::Result<ParsedOutput> {
@@ -305,7 +316,12 @@ async fn generate_notes(
     };
 
     let emoji = ctx.defaults.emoji.unwrap_or(true);
-    let system = prompt::system_prompt(ctx.system_extra.as_deref(), emoji, include_changelog);
+    let system = prompt::system_prompt(
+        ctx.system_extra.as_deref(),
+        emoji,
+        include_release_notes,
+        include_changelog,
+    );
     let user_msg = prompt::user_prompt(&prompt::UserPromptContext {
         tag: &ctx.tag,
         prev_tag: &ctx.prev_tag,
@@ -320,7 +336,11 @@ async fn generate_notes(
     });
 
     job.prop("message", "Generating release notes...");
-    let tool_defs = tools::all_definitions(ctx.github_client.is_some(), include_changelog);
+    let tool_defs = tools::all_definitions(
+        ctx.github_client.is_some(),
+        include_release_notes,
+        include_changelog,
+    );
 
     let verify_links = !dry_run && ctx.defaults.verify_links.unwrap_or(true);
 
@@ -332,6 +352,7 @@ async fn generate_notes(
         repo_root: &ctx.repo_root,
         github: ctx.github_client.as_ref(),
         verify_links,
+        require_release_notes: include_release_notes,
         require_changelog: include_changelog,
         job,
     })
@@ -530,9 +551,54 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "Initial Release");
         assert!(parsed.changelog.contains("Main function"));
+    }
+
+    #[tokio::test]
+    async fn test_generate_notes_changelog_only() {
+        let repo = TempRepo::new();
+        repo.write_file("README.md", "# Hello");
+        repo.commit("initial commit");
+        repo.tag("v0.9.0");
+        repo.write_file("src/main.rs", "fn main() {}");
+        repo.commit("fix: repair main");
+        repo.tag("v1.0.0");
+
+        let mock_client = MockLlmClient::new(vec![TurnResponse {
+            tool_calls: vec![ToolCall {
+                id: "call_1".into(),
+                name: "submit_release_notes".into(),
+                input: json!({ "changelog": "## Fixed\n- Repaired main" }),
+            }],
+            text: None,
+            stop_reason: StopReason::ToolUse,
+            usage: fake_usage(),
+        }]);
+
+        let ctx = Context {
+            repo_root: repo.path().to_path_buf(),
+            owner_repo: "test/repo".into(),
+            tag: "v1.0.0".into(),
+            prev_tag: "v0.9.0".into(),
+            client: Box::new(mock_client),
+            defaults: Defaults {
+                verify_links: Some(false),
+                ..Defaults::default()
+            },
+            system_extra: None,
+            context: None,
+            github_client: None,
+        };
+
+        let job = Arc::new(ProgressJobBuilder::new().build());
+        let parsed = generate_notes(&ctx, false, false, true, &job)
+            .await
+            .unwrap();
+        assert_eq!(parsed.changelog, "## Fixed\n- Repaired main");
+        assert!(parsed.release_title.is_empty());
+        assert!(parsed.release_body.is_empty());
     }
 
     #[tokio::test]
@@ -589,7 +655,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "Title");
         assert_eq!(parsed.release_body, "Body");
     }
@@ -872,7 +938,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0");
         assert!(parsed.release_body.contains("main entry point"));
     }
@@ -954,7 +1020,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0");
         assert!(parsed.release_body.contains("greeting"));
     }
@@ -1091,7 +1157,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.release_title, "v1.0.0 - Feature Release");
         assert!(parsed.changelog.contains("feature"));
     }
@@ -1170,7 +1236,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         publish(&opts, &ctx, &parsed, &job).await.unwrap();
         // wiremock expect(1) verifies PATCH was called
     }
@@ -1226,7 +1292,7 @@ mod tests {
         };
 
         let job = Arc::new(ProgressJobBuilder::new().build());
-        let parsed = generate_notes(&ctx, false, true, &job).await.unwrap();
+        let parsed = generate_notes(&ctx, false, true, true, &job).await.unwrap();
         assert_eq!(parsed.usage.input_tokens, 250);
         assert_eq!(parsed.usage.output_tokens, 125);
     }

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,4 +1,9 @@
-pub fn system_prompt(extra: Option<&str>, emoji: bool, include_changelog: bool) -> String {
+pub fn system_prompt(
+    extra: Option<&str>,
+    emoji: bool,
+    include_release_notes: bool,
+    include_changelog: bool,
+) -> String {
     let mut prompt = r#"You are an expert technical writer generating release notes for a software project.
 
 You have access to tools to browse the repository:
@@ -13,7 +18,12 @@ You have access to tools to browse the repository:
 
 Use these tools to understand what changed and why. Read relevant source files, PR descriptions, and diffs to write accurate, insightful release notes.
 
-When you are done researching, call the `submit_release_notes` tool with the requested fields.
+When you are done researching, call the `submit_release_notes` tool with the requested fields."#
+        .to_string();
+
+    if include_release_notes {
+        prompt.push_str(
+            r#"
 
 ### `release_title`
 A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as "vX.Y.Z: your title").
@@ -53,6 +63,26 @@ Each section needs a distinct job:
 - Categorized sections carry the concrete details, PR links, authors, useful examples, and compatibility notes.
 
 Avoid saying the same change three times. If a change appears in Highlights, keep the categorized bullet focused on extra detail or omit the duplicate detail entirely. Prefer fewer, denser bullets over repeated summaries.
+"#,
+        );
+    }
+
+    if include_changelog {
+        let length_guidance = if include_release_notes {
+            "Keep this substantially shorter than `release_body`; group related changes and omit minor or internal work so both artifacts fit in one response."
+        } else {
+            "Group related changes and omit minor or internal work so the changelog stays concise."
+        };
+        prompt.push_str(&format!(
+            r#"
+
+### `changelog`
+A concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized bullet points. Reference relevant PRs, issues, and commits as markdown links — e.g. `[#123](https://github.com/OWNER/REPO/pull/123)` for PRs/issues or `[abc1234](https://github.com/OWNER/REPO/commit/abc1234)` for commits. {length_guidance}"#,
+        ));
+    }
+
+    prompt.push_str(
+        r#"
 
 ## Guidelines
 
@@ -60,16 +90,8 @@ Write clearly and concisely. Focus on what matters to END USERS of the software.
 
 IMPORTANT: Only include changes that affect end users. Omit purely internal changes such as CI/CD pipeline updates, linter configurations, pre-commit hooks, build caching, code formatting, internal refactors, dependency updates (unless they fix a user-facing bug or add a user-facing feature), and dev tooling changes. If a release has no user-facing changes, say so briefly rather than padding the notes with internal details.
 
-Be honest about the scope of a release. If it only has one or two user-facing changes, say that — don't inflate it into something bigger than it is. A short, accurate release note is always better than a long, padded one."#.to_string();
-
-    if include_changelog {
-        prompt.push_str(
-            r#"
-
-### `changelog`
-A concise changelog entry using Keep a Changelog categories (## Added, ## Fixed, etc). No version header — just the categorized bullet points. Reference relevant PRs, issues, and commits as markdown links — e.g. `[#123](https://github.com/OWNER/REPO/pull/123)` for PRs/issues or `[abc1234](https://github.com/OWNER/REPO/commit/abc1234)` for commits. Keep this substantially shorter than `release_body`; group related changes and omit minor or internal work so both artifacts fit in one response."#,
-        );
-    }
+Be honest about the scope of a release. If it only has one or two user-facing changes, say that — don't inflate it into something bigger than it is. A short, accurate release note is always better than a long, padded one."#,
+    );
 
     if !emoji {
         prompt.push_str("\n\nDo NOT use emoji anywhere in the output — not in headings, titles, bullet points, or prose.");
@@ -186,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_system_prompt_default() {
-        let prompt = system_prompt(None, true, true);
+        let prompt = system_prompt(None, true, true, true);
         assert!(prompt.contains("submit_release_notes"));
         assert!(prompt.contains("Keep a Changelog"));
         assert!(prompt.contains("10+ distinct user-facing changes"));
@@ -199,21 +221,30 @@ mod tests {
 
     #[test]
     fn test_system_prompt_no_emoji() {
-        let prompt = system_prompt(None, false, true);
+        let prompt = system_prompt(None, false, true, true);
         assert!(prompt.contains("Do NOT use emoji"));
     }
 
     #[test]
     fn test_system_prompt_with_extra() {
-        let prompt = system_prompt(Some("Always mention cats"), true, true);
+        let prompt = system_prompt(Some("Always mention cats"), true, true, true);
         assert!(prompt.contains("Always mention cats"));
     }
 
     #[test]
     fn test_system_prompt_detailed_only_omits_changelog_request() {
-        let prompt = system_prompt(None, true, false);
+        let prompt = system_prompt(None, true, true, false);
         assert!(!prompt.contains("### `changelog`"));
         assert!(prompt.contains("### `release_body`"));
+    }
+
+    #[test]
+    fn test_system_prompt_changelog_only_omits_release_notes_request() {
+        let prompt = system_prompt(None, true, false, true);
+        assert!(prompt.contains("### `changelog`"));
+        assert!(!prompt.contains("### `release_title`"));
+        assert!(!prompt.contains("### `release_body`"));
+        assert!(!prompt.contains("shorter than `release_body`"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -44,14 +44,18 @@ impl ToolCache {
     }
 }
 
-pub fn all_definitions(has_github: bool, include_changelog: bool) -> Vec<ToolDefinition> {
+pub fn all_definitions(
+    has_github: bool,
+    include_release_notes: bool,
+    include_changelog: bool,
+) -> Vec<ToolDefinition> {
     let mut defs = vec![
         read_file::definition(),
         list_files::definition(),
         grep::definition(),
         git_show::definition(),
         get_commits::definition(),
-        submit_release_notes::definition(include_changelog),
+        submit_release_notes::definition(include_release_notes, include_changelog),
     ];
     if has_github {
         defs.push(get_pr::definition());
@@ -102,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_all_definitions_without_github() {
-        let defs = all_definitions(false, false);
+        let defs = all_definitions(false, true, false);
         assert_eq!(defs.len(), 6);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"read_file"));
@@ -115,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_all_definitions_with_github() {
-        let defs = all_definitions(true, true);
+        let defs = all_definitions(true, true, true);
         assert_eq!(defs.len(), 9);
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert!(names.contains(&"get_pr"));

--- a/src/tools/submit_release_notes.rs
+++ b/src/tools/submit_release_notes.rs
@@ -2,18 +2,20 @@ use serde_json::json;
 
 use crate::llm::ToolDefinition;
 
-pub fn definition(include_changelog: bool) -> ToolDefinition {
-    let mut properties = json!({
-        "release_title": {
+pub fn definition(include_release_notes: bool, include_changelog: bool) -> ToolDefinition {
+    let mut properties = json!({});
+    let mut required = Vec::new();
+    if include_release_notes {
+        properties["release_title"] = json!({
             "type": "string",
             "description": "A catchy, concise title for the GitHub release (no # prefix, no version tag — the version will be prepended automatically as 'vX.Y.Z: your title')."
-        },
-        "release_body": {
+        });
+        properties["release_body"] = json!({
             "type": "string",
             "description": "Detailed GitHub release notes in markdown. Follow the template from the system prompt: narrative summary, optional Highlights only for broad releases where they synthesize themes instead of duplicating categorized bullets, categorized sections (Added, Fixed, Changed, etc.), optional Breaking Changes, optional New Contributors, and a Full Changelog link."
-        }
-    });
-    let mut required = vec!["release_title", "release_body"];
+        });
+        required.extend(["release_title", "release_body"]);
+    }
     if include_changelog {
         properties["changelog"] = json!({
             "type": "string",
@@ -39,7 +41,7 @@ mod tests {
 
     #[test]
     fn detailed_only_schema_omits_changelog() {
-        let definition = definition(false);
+        let definition = definition(true, false);
         assert!(definition.input_schema["properties"]["changelog"].is_null());
         assert_eq!(
             definition.input_schema["required"],
@@ -49,11 +51,19 @@ mod tests {
 
     #[test]
     fn combined_schema_requires_changelog() {
-        let definition = definition(true);
+        let definition = definition(true, true);
         assert!(definition.input_schema["properties"]["changelog"].is_object());
         assert_eq!(
             definition.input_schema["required"],
             json!(["release_title", "release_body", "changelog"])
         );
+    }
+
+    #[test]
+    fn changelog_only_schema_omits_release_notes() {
+        let definition = definition(false, true);
+        assert!(definition.input_schema["properties"]["release_title"].is_null());
+        assert!(definition.input_schema["properties"]["release_body"].is_null());
+        assert_eq!(definition.input_schema["required"], json!(["changelog"]));
     }
 }


### PR DESCRIPTION
## Summary
- request only the artifacts needed by the selected output mode
- let concise-only generation submit a changelog without unused release title or body fields
- tailor max-token retry guidance to the requested artifacts
- safely coerce complete malformed submissions even when the model stops at its token limit

## Root cause
The submission schema and agent validation always required GitHub release fields, including for concise-only runs. Retry guidance also mentioned changelog constraints in modes that did not request a changelog, while max-token responses were excluded from otherwise safe type coercion.

This follows up on review feedback from #223 after that PR was merged.

## Validation
- cargo +1.95.0 test
- RUSTUP_TOOLCHAIN=1.95.0 mise run lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core LLM submission validation and salvage paths; risk is mitigated by broad new tests but wrong flag wiring could accept incomplete or reject valid output in some modes.
> 
> **Overview**
> Generation now **requests and validates only the outputs the CLI mode needs**, instead of always requiring GitHub `release_title` / `release_body`.
> 
> **Concise / changelog-only runs** can submit just `changelog`: `submit_release_notes` schema, system prompt, and agent validation (`require_release_notes` + existing `require_changelog`) are aligned. `generate` sets `include_release_notes` from `github_release || !concise` and skips release-title normalization when release notes are not produced.
> 
> **Retry and salvage behavior** is mode-aware: malformed-submission messages and max-token hints name only the required fields; after repeated malformed submits, **lenient coercion can succeed even when the model stopped at `max_tokens`** (previously blocked by stop reason).
> 
> Tests cover changelog-only submission, schema variants, and generate integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7654539f83f620a65f68d274e940adb794d6288d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->