### PR TITLE
v1.2.3: Maintenance Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.3](https://github.com/jdx/communique/releases/tag/v1.2.3) - 2026-07-14
+
+### Changed
+
+- *(ci)* Update pinned `actions/setup-node` commit (v6.4.0 → v6.5.0) to fix a Zizmor `ref-version-mismatch` audit failure ([#227](https://github.com/jdx/communique/pull/227))
+
 ## [1.2.2](https://github.com/jdx/communique/releases/tag/v1.2.2) - 2026-07-14
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.2"
+version = "1.2.3"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.2.2"
+version "1.2.3"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.2",
+  "version": "1.2.3",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.2
+**Version**: 1.2.3
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A maintenance-only release. The single change updates a pinned CI action in the docs deploy workflow to satisfy a supply-chain audit — there are no user-facing changes to communique itself.

## Changed

- *(ci)* Updated the pinned `actions/setup-node` commit in the docs deploy workflow (v6.4.0 → v6.5.0) and aligned its version comment so Zizmor's `ref-version-mismatch` audit passes. ([#227](https://github.com/jdx/communique/pull/227)) (@jdx)

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/docs metadata only; no runtime or application logic changes in the PR diff.
> 
> **Overview**
> **v1.2.3** is a maintenance release: the crate and CLI metadata move from **1.2.2** to **1.2.3** (`Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and generated `docs/cli` artifacts).
> 
> `CHANGELOG.md` adds a **[1.2.3]** section recording the only shipped change—pinning `actions/setup-node` **v6.4.0 → v6.5.0** in the docs deploy workflow to clear Zizmor’s `ref-version-mismatch` audit ([#227](https://github.com/jdx/communique/pull/227)). The **Unreleased** note that bumps the default model to `claude-opus-4-8` stays under Unreleased and is not part of this release entry.
> 
> There are **no Rust or CLI behavior changes** in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769ded56155ba8fb4cdecc6cf3667ab17e59cd35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->