### PR TITLE
fix(ci): update setup-node pin

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary

- update the pinned `actions/setup-node` commit from v6.4.0 to v6.5.0
- make the version comment match the exact immutable pin

## Why

The mutable `v6` tag advanced to v6.5.0 while the workflow remained pinned to the v6.4.0 commit. Zizmor's online `ref-version-mismatch` audit treated the mismatched `# v6` comment as a medium-severity finding and failed CI with exit code 13.

## Validation

- `git diff --check`
- `docker run --rm -v /Users/jdx/src/communique-zizmor-fix:/src -w /src ghcr.io/zizmorcore/zizmor:latest .`
  - zizmor v1.26.1: `No findings to report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency pin and comment change in the docs deploy workflow; no application or security logic affected.
> 
> **Overview**
> Updates the **Deploy Docs** workflow so `actions/setup-node` uses the v6.5.0 commit SHA and the inline comment says `# v6.5.0` instead of the generic `# v6`.
> 
> This aligns the immutable pin with the labeled version so Zizmor’s `ref-version-mismatch` check passes (the old pin was still on v6.4.0 while the comment implied the moving `v6` tag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dee255d0231349e481a9972541c4f4ac322f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->