### PR TITLE
v1.2.4: Maintenance Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.4](https://github.com/jdx/communique/releases/tag/v1.2.4) - 2026-07-20
+
+## Changed
+
+- *(deps)* Update `jdx/mise-action` digest to `dad1bfd` ([#229](https://github.com/jdx/communique/pull/229))
+- *(deps)* Lock file maintenance ([#230](https://github.com/jdx/communique/pull/230))
+
 ## [1.2.3](https://github.com/jdx/communique/releases/tag/v1.2.3) - 2026-07-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.2.3"
+version "1.2.4"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.3
+**Version**: 1.2.4
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -165,7 +165,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
     let github_token = std::env::var("GITHUB_TOKEN").ok();
 
     if opts.github_release && github_token.is_none() {
-        return Err(crate::error::Error::GitHub(
+        Err(crate::error::Error::GitHub(
             "GITHUB_TOKEN is required for --github-release".into(),
         ))?;
     }
@@ -216,7 +216,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
         .base_url
         .clone()
         .or(defaults.base_url.clone())
-        .and_then(|u| if u.is_empty() { None } else { Some(u) });
+        .filter(|u| !u.is_empty());
 
     let client = providers::build_client(&provider, api_key, model, max_tokens, base_url);
 


### PR DESCRIPTION
A maintenance-only release with no user-facing changes. Both changes are automated dependency housekeeping and have no impact on the `communique` CLI or its output.

## Changed

- *(deps)* Updated the pinned `jdx/mise-action` digest (`e6a8b39` → `dad1bfd`). Internal CI only. ([#229](https://github.com/jdx/communique/pull/229)) (@renovate)
- *(deps)* Refreshed lock files to the latest dependency versions. Internal only. ([#230](https://github.com/jdx/communique/pull/230)) (@renovate)

**Full Changelog**: https://github.com/jdx/communique/commits/v1.2.4

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and equivalent refactors only; no new generate behavior beyond existing defaults.
> 
> **Overview**
> **v1.2.4** is a patch release: version strings are bumped everywhere the CLI exposes them (`Cargo.toml`, usage spec, generated CLI docs), and **CHANGELOG** gains a dated **1.2.4** section for Renovate CI/lockfile work. **[Unreleased]** also records the default Anthropic model moving to **`claude-opus-4-8`**.
> 
> In **`gather_context`** (`generate.rs`), the missing-`GITHUB_TOKEN` path uses `Err(...)?` instead of `return Err(...)`, and empty `base_url` values are dropped with **`.filter(|u| !u.is_empty())`** instead of an `and_then`—same behavior, slightly clearer Rust.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dfc36d4b5a5e8a0244ba4320b410d75c0af9c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and CLI version to **1.2.4** across user-facing documentation and metadata.
  * Added the 1.2.4 changelog entry, including maintenance updates.
* **Bug Fixes**
  * Improved handling of missing GitHub credentials when generating release information.
  * Improved handling of empty base URL settings during context generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->