### PR TITLE
v1.2.4: Keep draft release tags intact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.2.4](https://github.com/jdx/communique/releases/tag/v1.2.4) - 2026-07-26
+
+## Fixed
+
+- *(github)* Keep a draft release's tag when rewriting its notes, so it stays attached to its version instead of becoming `untagged-<hash>` ([#241](https://github.com/jdx/communique/pull/241))
+
+## Changed
+
+- Updated `clx` to v2.1.1 for cleaner progress display (synchronized in-place redraws, no duplicated frames) ([#235](https://github.com/jdx/communique/pull/235))
+
 ## [1.2.3](https://github.com/jdx/communique/releases/tag/v1.2.3) - 2026-07-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2024"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -1,6 +1,6 @@
 name communique
 bin communique
-version "1.2.3"
+version "1.2.4"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -332,7 +332,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI"

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.3
+**Version**: 1.2.4
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -165,7 +165,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
     let github_token = std::env::var("GITHUB_TOKEN").ok();
 
     if opts.github_release && github_token.is_none() {
-        return Err(crate::error::Error::GitHub(
+        Err(crate::error::Error::GitHub(
             "GITHUB_TOKEN is required for --github-release".into(),
         ))?;
     }
@@ -216,7 +216,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
         .base_url
         .clone()
         .or(defaults.base_url.clone())
-        .and_then(|u| if u.is_empty() { None } else { Some(u) });
+        .filter(|u| !u.is_empty());
 
     let client = providers::build_client(&provider, api_key, model, max_tokens, base_url);
 


### PR DESCRIPTION
A small release with two user-facing changes: a fix that prevents draft releases from losing their tag when communique rewrites their notes, plus a progress-display refresh from an updated `clx`.

## Fixed

- **Draft releases keep their tag** — When `communique generate --github-release` rewrote a release's title and body, GitHub would regenerate a *draft* release's `tag_name` as `untagged-<hash>` because the PATCH omitted the tag, silently detaching the release from its version and breaking downstream steps like `gh release upload`. communique now always sends `tag_name` on update (`update_release` requires the tag rather than accepting an optional value), so draft releases stay addressable by their version. Published releases are unaffected — resending an existing tag is a no-op. ([#241](https://github.com/jdx/communique/pull/241)) (@jdx)

## Changed

- **Cleaner progress output** — Updated `clx` to v2.1.1, which wraps in-place progress redraws in synchronized updates and prevents duplicated frames during `println()`, so communique's live progress display renders more cleanly. ([#235](https://github.com/jdx/communique/pull/235))

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and two equivalent refactors in `generate`; no new behavior visible in the diff beyond documented prior fixes.
> 
> **Overview**
> **Release v1.2.4** — version strings are updated across `Cargo.toml`, lockfile, usage spec, and generated CLI docs. `CHANGELOG.md` adds the **1.2.4** section documenting a GitHub fix (draft releases keep their tag when notes are rewritten) and a **clx** v2.1.1 dependency bump for cleaner progress output.
> 
> In `src/generate.rs`, the only code edits are style refactors: missing `GITHUB_TOKEN` with `--github-release` uses `Err(...)?` instead of `return Err(...)`, and empty `base_url` values are dropped via `.filter(|u| !u.is_empty())` instead of `and_then`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3411101b044156e5c85f3706c742a6a0f39c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->