### PR TITLE
fix(github): keep a draft release's tag when rewriting its notes

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -376,6 +376,7 @@ async fn publish(
             Some(release) => {
                 gh.update_release(
                     release.id,
+                    &release.tag_name,
                     Some(&parsed.release_title),
                     Some(&parsed.release_body),
                 )

--- a/src/github.rs
+++ b/src/github.rs
@@ -51,6 +51,14 @@ pub struct Label {
 
 #[derive(Debug, Serialize)]
 struct UpdateRelease {
+    /// Always sent, never skipped.
+    ///
+    /// GitHub regenerates a *draft* release's `tag_name` as `untagged-<hash>`
+    /// when a PATCH omits it. The draft then no longer answers to its tag, and
+    /// anything downstream that addresses it by tag — `gh release upload`, for
+    /// one — fails with "release not found". Re-sending the tag we already know
+    /// keeps the association intact and is a no-op for published releases.
+    tag_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -108,14 +116,20 @@ impl GitHubClient {
         Ok(releases.into_iter().find(|r| r.tag_name == tag))
     }
 
+    /// Update a release's title and body, preserving its tag.
+    ///
+    /// `tag` is required rather than optional because omitting it is precisely
+    /// the bug this signature exists to prevent — see [`UpdateRelease::tag_name`].
     pub async fn update_release(
         &self,
         release_id: u64,
+        tag: &str,
         title: Option<&str>,
         body: Option<&str>,
     ) -> Result<()> {
         let url = self.api_url(&format!("/releases/{release_id}"));
         let payload = UpdateRelease {
+            tag_name: tag.to_string(),
             name: title.map(String::from),
             body: body.map(String::from),
         };
@@ -228,7 +242,7 @@ impl GitHubClient {
 mod tests {
     use super::*;
     use serde_json::json;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{body_partial_json, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     async fn setup() -> (MockServer, GitHubClient) {
@@ -299,7 +313,31 @@ mod tests {
             .await;
 
         client
-            .update_release(123, Some("Title"), Some("Body"))
+            .update_release(123, "v1.0.0", Some("Title"), Some("Body"))
+            .await
+            .unwrap();
+    }
+
+    /// The PATCH must carry `tag_name`.
+    ///
+    /// GitHub regenerates a draft release's tag as `untagged-<hash>` when a
+    /// PATCH omits it, and the draft stops answering to its own tag. That broke
+    /// a real release: `gh release upload v0.0.3` failed with "release not
+    /// found" after this call had rewritten the notes, leaving seven built
+    /// binaries with nowhere to go.
+    #[tokio::test]
+    async fn update_release_preserves_the_tag() {
+        let (server, client) = setup().await;
+        Mock::given(method("PATCH"))
+            .and(path("/repos/owner/repo/releases/42"))
+            .and(body_partial_json(json!({"tag_name": "v0.0.3"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id": 42})))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        client
+            .update_release(42, "v0.0.3", Some("Title"), Some("Body"))
             .await
             .unwrap();
     }


### PR DESCRIPTION
**This broke a real release an hour ago.**

`update_release` PATCHed only `name` and `body`. GitHub regenerates a **draft** release's `tag_name` as `untagged-<hash>` when a PATCH omits it, so rewriting the notes silently detached the release from its own tag.

## What it did

In [jdx/tak](https://github.com/jdx/tak) the `Enhance release notes` job ran `communique generate v0.0.3 --github-release`. It produced a good title and body. It also left the release looking like this:

```
id=359891214  tag=untagged-249d854d4260ba5ec6ec  draft=true
name=v0.0.3: Keep measurements clean, and stop losing them
```

The next job then did `gh release upload v0.0.3 …` and got:

```
release not found
```

Seven freshly built binaries with nowhere to attach, on a version already published to crates.io — so not something you can fix by re-cutting. Recovery was a manual `PATCH tag_name=v0.0.3` followed by re-running the failed job.

Two things made it hard to see:

- The job runs with `continue-on-error: true`, so it reported **success** while breaking a downstream job.
- The failure surfaced two jobs later and pointed at the upload, not at the rewrite.

## Fix

`tag_name` is now always sent, and `update_release` takes the tag as a **required** argument rather than an `Option` — omitting it is precisely the bug, so the signature should not permit it. The call site passes `release.tag_name`, which was already being fetched and marked `#[allow(dead_code)]`.

Published releases are unaffected: resending their existing tag is a no-op.

## Test

`update_release_preserves_the_tag` matches on the PATCH body with `body_partial_json({"tag_name": "v0.0.3"})`. Reverting the field to `skip_serializing` fails it — checked, not assumed.

## Pre-existing on this checkout

`tools::grep` has three failing tests and clippy reports five errors. All of them are present on `origin/main` and untouched here. This branch is **176 passed against main's 175** — the difference is the test above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release publishing in CI; the change is narrow and regression-tested, but a mistake here could still break downstream `gh release upload` on draft releases.
> 
> **Overview**
> **GitHub release note updates now always send `tag_name` on PATCH**, so draft releases stay addressable by their version tag after `communique generate --github-release` rewrites title and body.
> 
> `update_release` takes a **required** `tag` argument and the `UpdateRelease` payload always includes `tag_name` (previously only `name` and `body` were sent). The `--github-release` path passes `release.tag_name` from the release already fetched by tag. Published releases are unchanged—resending the same tag is a no-op.
> 
> Adds **`update_release_preserves_the_tag`**, which asserts the PATCH body includes `tag_name` via `body_partial_json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4b4e21120d0e90872fc880518e6f13027c6d8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->