### PR TITLE
v1.3.0: Commands declare their effect on the world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.3.0](https://github.com/jdx/communique/releases/tag/v1.3.0) - 2026-07-28
+
+## Added
+
+- *(usage)* Declare what each command does to the world — every command and its state-changing flags now carry a `read`/`write`/`destructive` effect in the usage spec ([#240](https://github.com/jdx/communique/pull/240))
+
+## Changed
+
+- Updated `clx` to v3: no cursor escapes in text or quiet mode, and reflowed frames are cleared after a terminal resize ([#248](https://github.com/jdx/communique/pull/248))
+
 ## [1.2.4](https://github.com/jdx/communique/releases/tag/v1.2.4) - 2026-07-26
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.2.4"
+version = "1.3.0"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.2.4"
+version = "1.3.0"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name communique
 bin communique
-version "1.2.4"
+version "1.3.0"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -340,7 +340,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.2.4",
+  "version": "1.3.0",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.2.4
+**Version**: 1.3.0
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
This release teaches communique's usage spec what each command does to the world — `read`, `write`, or `destructive` — so tools built on the spec can tell a safe inspection from a state-changing one. It also picks up progress-display fixes from `clx` v3.

## Added

- *(usage)* Every communique command now carries an `effect` annotation in its usage spec, distinguishing read-only commands from those that modify or destroy state. `generate` and `sponsors` are `read`; `init` is `write`; and the flags that actually change things are raised accordingly — `--changelog`, `--github-release`, and `--output` on `generate` are `write`, and `init --force` is `destructive`. Because `effect` is per-command, `generate` is classified as `read` at its floor while its state-changing flags carry the higher effect (the effect of an invocation is the maximum of the command and its supplied flags). The regenerated `communique.usage.kdl` and `docs/cli` reflect these labels. ([#240](https://github.com/jdx/communique/pull/240)) (@jdx)

## Changed

- Updated `clx` to v3 for progress-display fixes: cursor escape sequences are no longer written in text or quiet mode, and a reflowed frame is now cleared after a terminal resize. ([#248](https://github.com/jdx/communique/pull/248))

**Full Changelog**: https://github.com/jdx/communique/commits/v1.3.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime logic in this diff.
> 
> **Overview**
> **Cuts release v1.3.0** by bumping the crate and generated CLI metadata from `1.2.4` to `1.3.0` in `Cargo.toml`, `Cargo.lock`, `communique.usage.kdl`, and `docs/cli`.
> 
> **Updates `CHANGELOG.md`** with a dated `[1.3.0]` section documenting the shipped work (usage `read`/`write`/`destructive` effects and `clx` v3 progress fixes), while `[Unreleased]` still only lists the upcoming default model bump to `claude-opus-4-8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169db152c42cbbf16f103c1e9f9be009f9d6992b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI usage specifications now identify each command’s world effects: read, write, or destructive.

* **Changed**
  * Updated the CLI to version 1.3.0.
  * Text and quiet modes no longer emit cursor escape sequences.
  * Reflowed frames are cleared after terminal resizing.
  * Updated displayed version information across CLI documentation and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->