### PR TITLE
fix(ci): align mise-action version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
+      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4.2.2
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
       - run: mise run render
@@ -43,7 +43,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
+      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4.2.2
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - run: mise x -- cargo llvm-cov --codecov --output-path codecov.json

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
+      - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4.2.2
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run release-plz
         id: release-plz


### PR DESCRIPTION
## Summary

- update the three `jdx/mise-action` pin comments from `v4` to `v4.2.2`
- keep the existing immutable commit pins unchanged

## Root cause

The pinned commit is the v4.2.2 release, while the moving `v4` tag now resolves to a different commit. zizmor's online `ref-version-mismatch` audit therefore rejected the annotations.

## Impact

The zizmor workflow no longer fails on these version-comment mismatches.

## Validation

- `mise x zizmor@1.27.0 -- zizmor .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only workflow annotation changes; no runtime or security behavior change.
> 
> **Overview**
> Updates inline version comments on three **`jdx/mise-action`** steps from **`v4`** to **`v4.2.2`** in **`ci.yml`** (CI and coverage jobs) and **`release-plz.yml`** (release-plz-pr job). The immutable commit SHA is unchanged; only the annotation next to the pin is corrected so it matches the release that commit represents.
> 
> This fixes **zizmor** **`ref-version-mismatch`** failures where the moving **`v4`** tag no longer matches the pinned **`v4.2.2`** commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9543bb726400313a048a6c8d8652a32db7b728e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->