### PR TITLE
fix(docs): repair Vue lockfile

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1471,6 +1471,18 @@
         "csstype": "^3.2.3"
       }
     },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.40",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.40.tgz",
+      "integrity": "sha512-XNJym9WpevhTVt1HuwOrCRJ5Q+9z4BjTMrDtjTrvx74SmUll8spNTw6whWJa9mEkO4PKn5TihI/bm/8ds2QVJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.40",
+        "@vue/runtime-dom": "3.5.40",
+        "@vue/shared": "3.5.40"
+      }
+    },
     "node_modules/@vue/shared": {
       "version": "3.5.40",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.40.tgz",


### PR DESCRIPTION
## Summary

- add the missing `@vue/server-renderer@3.5.40` package entry to the docs lockfile
- restore reproducible `npm ci` installs for the GitHub Pages workflow

## Root cause

The Vue 3.5.40 dependency update left `docs/package-lock.json` incomplete. npm 11 rejects the lockfile because Vue declares `@vue/server-renderer@3.5.40`, but that package entry was absent.

## Impact

The Deploy Docs workflow can install dependencies and publish the VitePress site again.

## Validation

- `npx --yes npm@11.16.0 ci`
- `npm run docs:build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only fix with no runtime or security logic changes; lowest risk for CI reliability.
> 
> **Overview**
> Repairs **`docs/package-lock.json`** after the Vue **3.5.40** bump by adding the missing **`@vue/server-renderer@3.5.40`** `node_modules` entry (with its compiler/runtime deps), which **`vue`** already lists as a dependency but was absent from the lockfile.
> 
> This unblocks **`npm ci`** on npm 11 and restores reproducible installs for the docs / GitHub Pages deploy workflow—no application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb5e98b7e007e6339f7721a90cdf62ab83c5461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->