### PR TITLE
chore(deps): use rust-aware cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "communique"
 version = "1.2.4"
 edition = "2024"
+resolver = "3"
 description = "Editorialized release notes powered by AI"
 repository = "https://github.com/jdx/communique"
 license = "MIT"


### PR DESCRIPTION
## Summary
- explicitly select Cargo resolver version 3
- make Rust-aware dependency resolution intentional and visible

## Why
Resolver 3 prefers dependency releases compatible with the applicable Rust version, reducing accidental toolchain incompatibilities during lockfile maintenance. Edition 2024 already implies resolver 3; declaring it explicitly keeps the dependency policy visible in the manifest.

## Validation
- `cargo metadata --locked --no-deps --format-version 1`

Communique does not currently declare a package `rust-version`; this PR does not invent or change its MSRV policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest line with no runtime or dependency version changes; edition 2024 already implied resolver 3.
> 
> **Overview**
> Adds **`resolver = "3"`** to the root **`Cargo.toml`**, making Rust-aware dependency resolution explicit instead of relying only on the edition 2024 default.
> 
> No dependency versions, lockfile, or **`rust-version`** policy are changed—only the resolver setting is documented in the manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16838805fddc8b4147a66505e0a7bfe20af814d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->