### PR TITLE
docs(contributing): standardize AI disclosures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Communiqué Development Guide
+
+## GitHub Interactions
+
+When AI contributes GitHub content—including a pull request description, review, pull request
+comment, or discussion post—append this disclosure:
+
+`*AI-assisted — Tool: <tool>; model: <provider>/<model>; version: <version-or-unavailable>.*`
+
+Use the exact model and version identifiers exposed by the runtime. Never infer or guess them; use
+`unavailable` when either value is not exposed.


### PR DESCRIPTION
## Summary
- expand the AI disclosure requirement to cover pull request descriptions and reviews as well as comments and discussions
- define one consistent disclosure format containing the tool, model, and version
- require `unavailable` when runtime identifiers are not exposed so agents do not guess

## Impact
AI-assisted GitHub contributions will carry a consistent, more informative disclosure across all contribution surfaces.

## Validation
- `git diff --check`

*AI-assisted — Tool: OpenAI Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Introduces **`AGENTS.md`** as the Communiqué development guide and documents how AI-assisted GitHub contributions must be labeled.
> 
> The new **GitHub Interactions** section requires appending a fixed disclosure on pull request descriptions, reviews, comments, and discussion posts: tool name, `provider/model`, and version. Agents must use runtime-exposed identifiers only and write `unavailable` when tool, model, or version is not exposed—no guessing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086293e4fdfa5784386351c4f488f0ddae3b5007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for disclosing AI-generated GitHub contributions.
  * Clarified how to handle unavailable model or tool identifiers without guessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->