### PR TITLE
v1.3.1: Lock File Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.3.1](https://github.com/jdx/communique/releases/tag/v1.3.1) - 2026-08-10
+
+### Changed
+
+- *(deps)* Update `clap_usage`/`usage-lib` to v5 ([#255](https://github.com/jdx/communique/pull/255), [#254](https://github.com/jdx/communique/pull/254))
+- *(deps)* Simplify Cargo version requirements; `Cargo.lock` unchanged ([#256](https://github.com/jdx/communique/pull/256))
+
 ## [1.3.0](https://github.com/jdx/communique/releases/tag/v1.3.0) - 2026-07-28
 
 ## Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "clap",
  "clap_usage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.0"
+version = "1.3.1"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name communique
 bin communique
-version "1.3.0"
+version "1.3.1"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 flag "-v --verbose" help="Enable verbose logging output" global=#true

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -340,7 +340,7 @@
   "config": {
     "props": {}
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.3.0
+**Version**: 1.3.1
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A small maintenance release. There are no user-facing behavior changes — just a dependency bump to the `clap_usage` v5 line and some Cargo manifest housekeeping.

## Changed

- Bumped `clap_usage`/`usage-lib` from v4 to v5. This is an internal dependency update with no expected change to communique's behavior. ([#255](https://github.com/jdx/communique/pull/255), [#254](https://github.com/jdx/communique/pull/254))
- Normalized `Cargo.toml` version requirements to their lowest compatibility-significant form (e.g. `toml` `1.0` → `1`); resolved versions in `Cargo.lock` are unchanged. ([#256](https://github.com/jdx/communique/pull/256)) (@jdx)

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic in the diff; intended as non-functional lockfile/dependency maintenance.
> 
> **Overview**
> **Cuts the v1.3.1 maintenance release** by bumping the crate version from `1.3.0` to `1.3.1` in `Cargo.toml`, `Cargo.lock`, and generated CLI metadata (`communique.usage.kdl`, `docs/cli/commands.json`, `docs/cli/index.md`).
> 
> **Documents 1.3.1 in `CHANGELOG.md`** with the dependency work from the release ( `clap_usage`/`usage-lib` v5 and simplified `Cargo.toml` version requirements with an unchanged lockfile). The `[Unreleased]` entry for the default model bump to `claude-opus-4-8` stays separate and is not part of the 1.3.1 section.
> 
> No runtime or CLI behavior changes appear in this diff—only versioning and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9cf3c52ac5c6c78bd64e1ecd876006aa6bf939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->