### PR TITLE
chore(deps): simplify cargo version requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # Communiqué Development Guide
 
+## Dependency Updates
+
+- Use the lowest compatibility-significant specificity in `Cargo.toml` (for example, `"1"` for stable 1.x dependencies).
+- When the existing manifest requirement accepts a routine dependency update, change only `Cargo.lock`.
+- Keep lockfile updates focused and avoid unrelated transitive dependency churn.
+
 ## GitHub Interactions
 
 When AI contributes GitHub content—including a pull request description, review, pull request

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,9 @@ Communiqué is a Rust CLI tool that generates AI-powered editorialized release n
 - Link verification (`links.rs`) checks all URLs in output before accepting submission
 - Tests use `wiremock` for HTTP mocking and `test_helpers::TempRepo` for git fixtures
 - The project dogfoods itself via `release-plz.yml` to generate its own release notes
+
+## Dependency Updates
+
+- Use the lowest compatibility-significant specificity in `Cargo.toml` (for example, `"1"` for stable 1.x dependencies).
+- When the existing manifest requirement accepts a routine dependency update, change only `Cargo.lock`.
+- Keep lockfile updates focused and avoid unrelated transitive dependency churn.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ log = "0.4"
 clap_usage = "5"
 clx = { version = "3", features = ["log"] }
 console = "0.16"
-toml = "1.0"
+toml = "1"
 xx = "2"
-strum = { version = "0.28.0", features = ["derive"] }
-futures-util = { version = "0.3.31", default-features = false }
+strum = { version = "0.28", features = ["derive"] }
+futures-util = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 wiremock = "0.6"


### PR DESCRIPTION
## Summary
- normalize stable Cargo requirements to their lowest compatibility-significant specificity
- document that routine compatible updates should only change `Cargo.lock`

`Cargo.lock` is unchanged.

## Validation
- `cargo check --locked`
- `cargo fmt --check`
- `cargo test --locked` (185 unit tests and 4 integration tests passed)

Strict Clippy currently fails on the pre-existing `items_after_test_module` lint in `src/providers/mod.rs`, unrelated to this manifest-only cleanup.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and documentation only; no runtime code or lockfile changes, so resolved dependency versions are unchanged.
> 
> **Overview**
> Documents how the repo handles dependency bumps: prefer the lowest compatibility-significant version strings in `Cargo.toml`, update only `Cargo.lock` when the manifest already allows a routine upgrade, and avoid unrelated transitive churn. The same guidance is added to **AGENTS.md** and **CLAUDE.md**.
> 
> **Cargo.toml** normalizes a few requirements to that style (`toml` `1.0` → `1`, `strum` `0.28.0` → `0.28`, `futures-util` `0.3.31` → `0.3`). **`Cargo.lock` is unchanged**, so resolved versions stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04dcfe2dd815b5e593693bb99da317554b02579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing dependency versions and lockfile updates.
  * Clarified how to keep dependency changes focused and avoid unrelated updates.

* **Chores**
  * Updated dependency version requirements to improve compatibility with compatible releases.
  * No changes were made to the product’s public functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->