### PR TITLE
v1.3.2: The usage-rs CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.3.2](https://github.com/jdx/communique/releases/tag/v1.3.2) - 2026-08-22
+
+## Changed
+
+- Replaced clap with the typed `usage-rs` CLI; the CLI, usage spec, and docs are now generated from the same derive metadata, with subcommand-required and unknown-flag-error behavior declared explicitly in the spec ([#265](https://github.com/jdx/communique/pull/265))
+
+## Fixed
+
+- Docs: prevent announcement banner layout shifts, honor the banner `expires` field, and enlarge the mobile dismiss target to 44px ([#266](https://github.com/jdx/communique/pull/266))
+- Docs: fix sponsor logo sizing so SVGs without intrinsic dimensions no longer collapse ([#263](https://github.com/jdx/communique/pull/263))
+
 ## [1.3.1](https://github.com/jdx/communique/releases/tag/v1.3.1) - 2026-08-10
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "clx",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,13 +1957,15 @@ dependencies = [
 
 [[package]]
 name = "usage-argv"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b9737d4a78f9407c5cd035cedd6fee9ceb0b99e3287237cb2c86b66eea9cab"
 
 [[package]]
 name = "usage-derive"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b230ac0b4408abfc7fdf134f77e9618d1d88a75e3056286e16f4c33d8b7d02"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1972,8 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a7fe976bd4d6e61e94a5bb1303373a7b335d775de3cab053d825f674285300"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jdx/communique"
 license = "MIT"
 
 [dependencies]
-usage-rs = { git = "https://github.com/jdx/usage", rev = "600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a", features = ["diagnostics"] }
+usage-rs = { version = "6", features = ["diagnostics"] }
 reqwest = { version = "0.13", features = ["rustls", "json"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name communique
 bin communique
-version "1.3.1"
+version "1.3.2"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 unknown_flags error

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -353,7 +353,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 
-**Version**: 1.3.1
+**Version**: 1.3.2
 
 - **Usage**: `communique [FLAGS] <SUBCOMMAND>`
 

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ run = [
 ]
 
 [tasks.build-usage]
-run = "cargo install --locked --root target/usage-cli --git https://github.com/jdx/usage --rev 600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a usage-cli"
+run = "cargo install --locked --root target/usage-cli --version 6.1.0 usage-cli"
 sources = ["Cargo.lock", "mise.toml"]
 outputs = ["target/usage-cli/bin/usage"]
 


### PR DESCRIPTION
A maintenance release whose one notable change is under the hood: communique's command-line parser has been rebuilt on the typed `usage-rs` CLI instead of clap. Runtime behavior is unchanged for normal use, plus a couple of docs-site fixes.

## Changed

- Replaced clap with the typed `usage-rs` CLI. The CLI, the checked-in `communique.usage.kdl` spec, and the rendered docs are now all generated from the same derive metadata, so command effects (`read`/`write`/`destructive`) live directly on the argument definitions rather than a separate overlay. A subcommand is still required and unknown flags are still treated as errors — these are now declared explicitly in the spec (`subcommand_required`, `unknown_flags error`). ([#265](https://github.com/jdx/communique/pull/265)) (@jdx)

## Fixed

- Docs: reserve the announcement banner's measured height before hydration so the navbar no longer shifts on repeat page loads, honor the banner's `expires` field, and enlarge the dismiss control to a 44px mobile touch target. ([#266](https://github.com/jdx/communique/pull/266)) (@jdx)
- Docs: give sponsor logos an explicit height so SVGs without intrinsic dimensions (like the new Entire logo) no longer collapse into empty footer tiles. ([#263](https://github.com/jdx/communique/pull/263)) (@jdx)

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version, changelog, and dependency-source changes only; no application logic is modified.
> 
> **Overview**
> Cuts **1.3.2** and records the clap → typed `usage-rs` CLI work plus two docs-site fixes in the changelog.
> 
> Switches `usage-rs` (and the `usage-cli` install in `mise.toml`) from a git rev to crates.io **6.1.0**, and bumps the crate/CLI spec/docs version from 1.3.1 to 1.3.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f55a18c38c6c0b1327dfdcd9292286acb2514db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->