### PR TITLE
docs: fix sponsor logo sizing

### DIFF
--- a/docs/.vitepress/theme/EndevSponsors.vue
+++ b/docs/.vitepress/theme/EndevSponsors.vue
@@ -136,8 +136,10 @@ onMounted(async () => {
 
 .EndevSponsorsLogo img {
   display: block;
-  max-height: 22px;
+  height: 22px;
   max-width: 120px;
+  object-fit: contain;
+  width: auto;
 }
 
 .EndevSponsorsCta {


### PR DESCRIPTION
## Summary

- give sponsor logos an explicit height while preserving their aspect ratio
- contain logos within the existing footer tile width

## Why

The new Entire logo SVG declares a `viewBox` but no intrinsic `width` or `height`. The footer previously set only maximum dimensions, so the image can collapse or render as an empty sponsor tile. Explicit sizing matches the working implementation already used by the mise and hk docs.

## Validation

- built the VitePress documentation site successfully

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only CSS in the sponsor footer component; no runtime, auth, or data changes.
> 
> **Overview**
> Fixes sponsor logos (especially SVGs without intrinsic `width`/`height`) collapsing or showing as empty tiles in the VitePress footer.
> 
> **`.EndevSponsorsLogo img`** now uses a fixed **`height: 22px`** (replacing **`max-height: 22px`**), plus **`object-fit: contain`** and **`width: auto`**, so logos keep aspect ratio while staying within the existing **`max-width: 120px`** tile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c68d9042e171e538617547ec83248a0a555be06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sponsor logo styling for consistent sizing and proportions.
  * Logos now fit within their allocated space without distortion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->