### PR TITLE
chore(deps): use usage 6.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,13 +1957,15 @@ dependencies = [
 
 [[package]]
 name = "usage-argv"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b9737d4a78f9407c5cd035cedd6fee9ceb0b99e3287237cb2c86b66eea9cab"
 
 [[package]]
 name = "usage-derive"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b230ac0b4408abfc7fdf134f77e9618d1d88a75e3056286e16f4c33d8b7d02"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1972,8 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "usage-rs"
-version = "6.0.0"
-source = "git+https://github.com/jdx/usage?rev=600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a#600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a7fe976bd4d6e61e94a5bb1303373a7b335d775de3cab053d825f674285300"
 dependencies = [
  "usage-argv",
  "usage-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/jdx/communique"
 license = "MIT"
 
 [dependencies]
-usage-rs = { git = "https://github.com/jdx/usage", rev = "600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a", features = ["diagnostics"] }
+usage-rs = { version = "6", features = ["diagnostics"] }
 reqwest = { version = "0.13", features = ["rustls", "json"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/mise.toml
+++ b/mise.toml
@@ -15,7 +15,7 @@ run = [
 ]
 
 [tasks.build-usage]
-run = "cargo install --locked --root target/usage-cli --git https://github.com/jdx/usage --rev 600c2287b7cd23a4841ad789a7dcb6dd7d8dd31a usage-cli"
+run = "cargo install --locked --root target/usage-cli --version 6.1.0 usage-cli"
 sources = ["Cargo.lock", "mise.toml"]
 outputs = ["target/usage-cli/bin/usage"]
 


### PR DESCRIPTION
## Summary

- replace the temporary usage git revision with the published usage-rs 6 release
- lock the usage crates to 6.1.0
- install usage-cli 6.1.0 for generated docs

This carries the dependency update separately from the partially completed release work in #258.

## Validation

- `cargo check --locked`
- `cargo test --locked` (183 tests)
- `mise run lint`
- `mise run render`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency source/version bump only; no application logic, auth, or data-handling changes.
> 
> **Overview**
> Switches `usage-rs` from a git revision of 6.0.0 to the published **6.1.0** crates.io release (`version = "6"`), and updates `Cargo.lock` accordingly.
> 
> The `build-usage` mise task now installs `usage-cli` **6.1.0** from crates.io instead of the same git pin, so CLI docs generation matches the library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78a8a34ca2c986abec1fa7fd9c201cb9565712e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the usage tooling to stable registry releases.
  - The usage build process now installs version 6.1.0 of the command-line tool.
  - Retained diagnostic support for usage-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->