### PR TITLE
v1.3.3: Built-in help & version flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
 
+## [1.3.3](https://github.com/jdx/communique/compare/v1.3.2...v1.3.3) - 2026-08-26
+
+### Fixed
+
+- *(ci)* preserve clippy warning failures ([#280](https://github.com/jdx/communique/pull/280))
+- update mbx to 0.4.0 ([#275](https://github.com/jdx/communique/pull/275))
+- use direct mbx command syntax ([#273](https://github.com/jdx/communique/pull/273))
+
+### Other
+
+- notarize the macOS release binary ([#285](https://github.com/jdx/communique/pull/285))
+- seed mbx cache for fork PRs ([#284](https://github.com/jdx/communique/pull/284))
+- add sponsor logos to readme ([#278](https://github.com/jdx/communique/pull/278))
+- *(deps)* update jdx/mise-action action to v4.2.5 ([#274](https://github.com/jdx/communique/pull/274))
+- disable caches in release workflows ([#277](https://github.com/jdx/communique/pull/277))
+- *(sponsors)* replace 37signals with omacom foundation ([#276](https://github.com/jdx/communique/pull/276))
+- *(ci)* adopt mbx for Rust builds ([#272](https://github.com/jdx/communique/pull/272))
+- *(deps)* bump usage to 6.4.0 ([#271](https://github.com/jdx/communique/pull/271))
+- generate release notes before publishing ([#270](https://github.com/jdx/communique/pull/270))
+- manage usage cli with mise ([#269](https://github.com/jdx/communique/pull/269))
+
+### Security
+
+- *(ci)* avoid inheriting workflow secrets ([#283](https://github.com/jdx/communique/pull/283))
+- *(ci)* isolate mbx OIDC permissions ([#282](https://github.com/jdx/communique/pull/282))
+- *(ci)* restrict trusted mbx runs to jdx ([#281](https://github.com/jdx/communique/pull/281))
+- *(ci)* route dependabot through fork-safe path ([#279](https://github.com/jdx/communique/pull/279))
+
 ## [1.0.4](https://github.com/jdx/communique/releases/tag/v1.0.4) - 2026-04-24
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "clx",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"


### PR DESCRIPTION
A small release. Bumping the `usage-rs` toolchain to 6.4.0 gives communique built-in `-h/--help` and `-V/--version` flags on the root command and every subcommand, and macOS release binaries are now notarized so browser-downloaded builds pass Gatekeeper without a "cannot be verified" prompt.

## Added

- Built-in `-h`/`--help` on the root command and each subcommand, plus `-V`/`--version` on the root command, courtesy of the `usage-rs` 6.4.0 upgrade. ([#271](https://github.com/jdx/communique/pull/271)) (@jdx)

  ```
  communique --version
  communique generate --help
  ```
- macOS release binaries are now submitted to Apple's notary service so downloads open without a Gatekeeper "cannot be verified" dialog. Binaries are signed with the hardened runtime and the release fails if notarization is rejected; if notary credentials aren't configured, releases still ship signed (un-notarized) with a warning. ([#285](https://github.com/jdx/communique/pull/285)) (@jdx)

## Changed

- CLI reference docs regenerated with usage 6.4.0, using a tighter, more compact layout for arguments and flags. ([#271](https://github.com/jdx/communique/pull/271)) (@jdx)

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.