### PR TITLE
chore: manage usage cli with mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,19 +5,14 @@ _.path = "target/debug"
 run = "cargo build"
 
 [tasks.render]
-depends = ["build", "build-usage"]
+depends = ["build"]
 run = [
   "communique usage > communique.usage.kdl",
   "rm -rf docs/cli && mkdir -p docs/cli",
-  "target/usage-cli/bin/usage g markdown -mf communique.usage.kdl --out-dir docs/cli --url-prefix /cli",
-  "target/usage-cli/bin/usage g json -f communique.usage.kdl > docs/cli/commands.json",
+  "usage g markdown -mf communique.usage.kdl --out-dir docs/cli --url-prefix /cli",
+  "usage g json -f communique.usage.kdl > docs/cli/commands.json",
   "git add communique.usage.kdl docs/cli",
 ]
-
-[tasks.build-usage]
-run = "cargo install --locked --root target/usage-cli --version 6.1.0 usage-cli"
-sources = ["Cargo.lock", "mise.toml"]
-outputs = ["target/usage-cli/bin/usage"]
 
 [tasks.lint]
 run = "hk check --all"
@@ -31,6 +26,7 @@ run = "npm i && exec npm run docs:dev"
 
 # rust is managed by rustup, not mise
 [tools]
+usage = "6.1.0"
 hk = "latest"
 pkl = "latest"
 ripgrep = "latest"


### PR DESCRIPTION
## Summary

- pin the precompiled usage 6.1.0 release in mise.toml
- use the mise-managed usage executable during docs rendering
- remove the custom cargo install task and target-local binary path

## Verification

- mise install usage@6.1.0
- usage --version
- mise run render
- mise run lint
- cargo test

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the rendering workflow to use the managed `usage` tool.
  * Simplified task dependencies by removing the separate usage-build step.
  * Updated the configured `usage-cli` version to 6.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->