### PR TITLE
chore: generate release notes before publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -78,7 +78,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [release-plz-release, upload-assets]
+    needs: [release-plz-release, upload-assets, enhance-release]
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: ubuntu-latest
     permissions:
@@ -92,7 +92,7 @@ jobs:
 
   enhance-release:
     name: Enhance release notes
-    needs: [release-plz-release, publish-release]
+    needs: release-plz-release
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- enhance Communiqué's own release-plz draft in parallel with asset uploads
- publish only after assets, generated notes, and sponsor normalization are ready
- leave the draft intact when enhancement fails

## Validation

- actionlint expression and workflow validation
- git diff --check
- verified the full ShellCheck finding is unchanged from the base revision

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI job-dependency change only; no application or security logic. A failed enhance job now blocks publishing, which is the intended safeguard.
> 
> **Overview**
> Reorders the release-plz pipeline so `enhance-release` runs on the draft in parallel with asset uploads, and `publish-release` waits for both.
> 
> GitHub releases stay draft until notes (and sponsor blurb) are written. If enhancement fails, the draft is not published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b1a549af0fb2fa2fe9078cf40a24c43b29e0005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process by ensuring release enhancements are completed before publication.
  * Updated workflow sequencing for more reliable release delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

