### PR TITLE
fix: use direct mbx command syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
       - run: mise run lint
-      - run: mbx build test
+      - run: mbx test
       - run: cargo audit
 
   coverage:
@@ -48,7 +48,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
-      - run: mbx build llvm-cov --codecov --output-path codecov.json
+      - run: mbx llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: codecov.json

--- a/hk.pkl
+++ b/hk.pkl
@@ -3,7 +3,7 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 
 local linters = new Mapping<String, Step> {
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx build clippy --manifest-path {{workspace_indicator}} --quiet"
+        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet"
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
 }

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 _.path = "target/debug"
 
 [tasks.build]
-run = "mbx build build"
+run = "mbx build"
 
 [tasks.render]
 depends = ["build"]


### PR DESCRIPTION
Use mr-boxington current direct Cargo-subcommand syntax instead of the legacy mbx build wrapper form. This intentionally targets the next mbx release; the project remains locked to 0.3.0 until that release is available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only CLI renames in CI and dev hooks; no runtime or application code changes, but CI will fail until the installed mbx version supports the new syntax.
> 
> **Overview**
> Replaces the legacy **`mbx build <cargo-subcommand>`** wrapper with **direct `mbx` subcommands** across CI, pre-commit hooks, and mise tasks.
> 
> **CI** now runs `mbx test` and `mbx llvm-cov` instead of `mbx build test` and `mbx build llvm-cov`. **`mise.toml`**’s build task uses `mbx build` rather than `mbx build build`. **`hk.pkl`** invokes `mbx clippy` for the cargo-clippy check.
> 
> This aligns the repo with mr-boxington’s current Cargo-subcommand CLI ahead of the next mbx release (the project stays on 0.3.0 until that release ships).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc764561892c65bc255ee517065aa11649aae0cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->