### PR TITLE
fix: update mbx to 0.4.0

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
-        version: 0.3.0
+        version: 0.4.0
         backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique

--- a/mise.lock
+++ b/mise.lock
@@ -3,47 +3,47 @@
 lockfile_version = 1
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.3.0"
+version = "0.4.0"
 backend = "github:jdx/mr-boxington"
 specifiers = [
-    "0.3.0",
+    "0.4.0",
     "latest",
 ]
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:4be02935fb0c1892b659c8146e07fe092fb12f6c4e86c6ebbc3b63449d5dcb25"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704880"
+checksum = "sha256:ed81dab87775bcc8764c7257d8bea0dd8b7f811d6263b71bc7cd83a879661593"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719396"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:65ef46c20761ffd1d930638c3ff2d237535a98f28968929f04f195bfdd258e77"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704890"
+checksum = "sha256:b288265404b8fa4620ea1d082ba9b33a0a1695212d88a385e76aa07a743da250"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719409"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:1803cec79be0b753fc3af23044edc46fd81ffdf9d66fcb7b6637cfb22cc6db4a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704881"
+checksum = "sha256:416cab92e23c4652183e4a794af3fdcbc50b56296d8c09f8b6548e7577416307"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719398"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-x64"]
-checksum = "sha256:72a98d019b83859e465d30a91422e7b2eb72cf53fb42e116a277865310392c0c"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704883"
+checksum = "sha256:9f1016b0592ffd3b4b4000640223e10a2100cc6136d722fac5c4829cb89fc7ed"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719400"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:9d99f1f57789e88f4870ac61fd6c4e2ceec5ed532f4c9c8e9be4f32663a1fd16"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/526704879"
+checksum = "sha256:f841b1907cf86c54db4d3d2d1e88f87303ccc8f720efff90b6331d7d5592bf4e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.4.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/529719397"
 
 [[tools.hk]]
 version = "1.56.1"


### PR DESCRIPTION
## Summary

- update the committed mise lock from mbx 0.3.0 to 0.4.0
- update CI setup to request mbx 0.4.0

## Validation

- installed the committed lock and confirmed `mbx 0.4.0`
- evaluated the mise configuration and task list
- confirmed `mbx build` direct syntax

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin and lockfile-only change for the CI/build-cache tool; no application or auth logic is modified.
> 
> **Overview**
> Bumps **mbx** (`github:jdx/mr-boxington`) from **0.3.0** to **0.4.0** so local installs and CI use the same binary.
> 
> The composite action `.github/actions/mbx` now passes `version: 0.4.0` to `jdx/mr-boxington-action`. **`mise.lock`** is regenerated with new release URLs, asset IDs, and per-platform checksums for Linux, macOS, and Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b67ab087f3f5b22e14aa9183c7e7c3e598fda97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s automation tooling to a newer release.
  - Improved compatibility and reliability for automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->