### PR TITLE
chore(sponsors): replace 37signals with omacom foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ publish directly to a GitHub Release.
 
 ## Sponsors
 
-communique is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
+communique is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ fn init(force: bool) -> miette::Result<()> {
 
 fn sponsors() -> miette::Result<()> {
     println!(
-        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  37signals - https://37signals.com\n\nView all sponsors: https://jdx.dev/sponsors.html"
+        "communique and the jdx.dev open source tools are sponsored by:\n\n  entire.io - https://entire.io\n  Omacom Foundation - https://omarchy.org/patrons/\n\nView all sponsors: https://jdx.dev/sponsors.html"
     );
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -22,7 +22,7 @@ fn test_sponsors_command() {
         stderr
     );
     assert!(stdout.contains("entire.io"), "stdout: {stdout}");
-    assert!(stdout.contains("37signals"), "stdout: {stdout}");
+    assert!(stdout.contains("Omacom Foundation"), "stdout: {stdout}");
     assert!(
         stdout.contains("https://jdx.dev/sponsors.html"),
         "stdout: {stdout}"


### PR DESCRIPTION
## Summary
- replace 37signals with the Omacom Foundation in the README
- update the `communique sponsors` output and integration assertion

## Verification
- `cargo fmt --all --check`
- `cargo test test_sponsors_command`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*