### PR TITLE
ci: disable caches in release workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,7 +22,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
           persist-credentials: false
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -102,7 +101,6 @@ jobs:
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           persist-credentials: false
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Enhance GitHub release with communique
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
@@ -149,7 +147,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache: false
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,6 @@ jobs:
         uses: taiki-e/setup-cross-toolchain-action@12b7ad4acfa95a1476779d6c06699b96ec1691f8 # v1
         with:
           target: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-        with:
-          shared-key: rust-${{ matrix.target }}
       - name: Upload binary (macOS signed)
         if: startsWith(matrix.os, 'macos')
         uses: taiki-e/upload-rust-binary-action@f0d45ae91ee7b8ee928de7a9d04d893a08bcbec6 # v1


### PR DESCRIPTION
## Summary

- remove persistent Rust caches from release artifact and release-plz jobs
- disable mise-action caching in release workflow setup
- preserve explicit artifact upload and download handoffs

## Validation

- ran actionlint over changed workflows
- audited release and publish entrypoints for Rust, Actions, Namespace, mise, Node, and mbx caches
- confirmed all remaining cache-capable setup is explicitly disabled for release paths

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that remove caching; no application code, secrets, or release artifact logic changes.
> 
> **Overview**
> Release and release-plz CI jobs no longer restore or save **Rust** build caches: the `Swatinem/rust-cache` step is removed from `release-plz-release`, `enhance-release`, and the reusable `release.yml` matrix (including per-target `shared-key` caching).
> 
> The **release-plz PR** job keeps `jdx/mise-action` but sets **`cache: false`** so mise tooling isn’t cached on that path either.
> 
> Binary upload/download and release-plz behavior are unchanged; builds on these workflows are expected to be colder and more reproducible at the cost of longer run times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84551041d64d28434fbc213993b006194c4438fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->