### PR TITLE
docs: add sponsor logos to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,24 @@ publish directly to a GitHub Release.
 
 ## Sponsors
 
-communique is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
-
-[View all sponsors](https://jdx.dev/sponsors.html).
+<p align="center">
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
+</p>
 
 ## Install
 


### PR DESCRIPTION
## Summary
- replace the text-only sponsor line with linked Entire and Omarchy wordmarks
- select dark- or light-background assets based on the reader theme
- retain the link to the complete sponsor list

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only presentation change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> The **Sponsors** section in `README.md` no longer lists Entire and Omacom Foundation as plain text links. It now uses a centered block with linked **wordmark images** for each sponsor.
> 
> Each logo uses a `<picture>` element so **dark-mode readers** get the dark-background SVG and **light-mode readers** get the on-light variant. The **View all sponsors** link to `jdx.dev/sponsors.html` is unchanged in purpose, just moved into the same centered layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93a6c50957a537e632415b6fa50b373f721f8fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->