### PR TITLE
security(ci): route dependabot through fork-safe path

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   ci:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write
@@ -36,7 +36,7 @@ jobs:
       - run: cargo audit
 
   coverage:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- treat Dependabot pull requests as fork-like for mbx cache selection
- use GitHub-hosted runners and the restore-only GitHub cache backend for those runs
- preserve Namespace and the server cache for trusted pushes and same-repository contributor PRs

## Validation

- `actionlint -shellcheck= .github/workflows/ci.yml`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which PRs use trusted runners and cache backends; misclassification could weaken isolation or break Dependabot CI, but the logic is a narrow bot check aligned with existing fork handling.
> 
> **Overview**
> **Dependabot pull requests** are now treated like fork PRs for CI isolation instead of only checking whether the head repo differs from the upstream.
> 
> For `ci` and `coverage`, **Dependabot PRs** run on `ubuntu-latest` rather than the internal `namespace-profile-endev-linux-amd64` runner. The composite **mbx** setup action uses the **GitHub** cache backend for those PRs instead of the trusted **server** backend at `cache.mise.jdx.dev`.
> 
> The condition is extended with `|| github.event.pull_request.user.login == 'dependabot[bot]'` in all three places so same-repo Dependabot updates no longer use the trusted runner or OIDC-backed cache path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086a0879a551f725fde32cae400143b55be3b125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->