### PR TITLE
fix(ci): preserve clippy warning failures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ yourself without skipping or weakening the check:
 ```sh
 cargo build
 cargo test
-cargo clippy --manifest-path Cargo.toml --quiet
+cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 ```
 
 If Cargo succeeds where mbx fails, or mbx introduces a papercut, please start a

--- a/hk.pkl
+++ b/hk.pkl
@@ -3,7 +3,7 @@ import "package://github.com/jdx/hk/releases/download/v1.44.3/hk@1.44.3#/Builtin
 
 local linters = new Mapping<String, Step> {
     ["cargo-clippy"] = (Builtins.cargo_clippy) {
-        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet"
+        check = "mbx clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
     }
     ["cargo-fmt"] = Builtins.cargo_fmt
 }


### PR DESCRIPTION
## Summary

- preserve Clippy warnings-as-errors when hk routes the check through mbx
- document the exact direct Cargo fallback

## Validation

- `pkl eval hk.pkl`

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and documentation only; no runtime or security behavior changes.
> 
> **Overview**
> Clippy is now run with **`-D warnings`** when lint goes through **mbx** in `hk.pkl`, so warnings fail the pre-commit / `mise run lint` path the same way a strict Cargo run would.
> 
> **CONTRIBUTING.md** documents the matching direct fallback: `cargo clippy ... -- -D warnings`, so contributors who bypass mbx don’t accidentally run a weaker check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c7a6cf73702459dbb841d5930eb2e09580d0cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->