### PR TITLE
security(ci): restrict trusted mbx runs to jdx

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'github' || 'server' }}
+        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write
@@ -36,7 +36,7 @@ jobs:
       - run: cargo audit
 
   coverage:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- reserve Namespace runners and the server cache for same-repository PRs authored by `jdx`
- route every other PR author, including dependency bots, through GitHub-hosted runners and GitHub cache
- keep trusted-only repository secrets unavailable to non-`jdx` PRs

## Validation

- `git diff --check`
- actionlint workflow and expression validation
- confirmed no dependency-bot-specific trust predicates remain

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request automation to use GitHub-hosted caching and runners for contributions from external contributors.
  * Maintained trusted infrastructure for same-repository pull requests by the designated maintainer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->