### PR TITLE
security(ci): isolate mbx OIDC permissions

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0
-        backend: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'github' || 'server' }}
+        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -1,0 +1,51 @@
+name: CI implementation
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  ci:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - run: rustup component add clippy rustfmt
+      - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
+      - run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff HEAD
+            exit 1
+          fi
+      - run: mise run lint
+      - run: mbx test
+      - run: cargo audit
+
+  coverage:
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/mbx
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+      - run: rustup component add llvm-tools-preview
+      - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
+      - run: mbx llvm-cov --codecov --output-path codecov.json
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          files: codecov.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,46 +9,35 @@ on:
 permissions: {}
 
 jobs:
-  ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+  trusted:
+    if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
       id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-      - run: rustup component add clippy rustfmt
-      - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
-      - run: mise run render
-      - name: assert render produces no diff
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::'mise run render' produced changes. Run it locally and commit."
-            git status
-            git diff HEAD
-            exit 1
-          fi
-      - run: mise run lint
-      - run: mbx test
-      - run: cargo audit
+    uses: ./.github/workflows/ci-impl.yml
+    secrets: inherit
 
-  coverage:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+  untrusted:
+    if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
+    uses: ./.github/workflows/ci-impl.yml
+
+  ci:
+    name: ci
+    if: ${{ always() && !cancelled() }}
+    permissions: {}
+    needs: [trusted, untrusted]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/mbx
-      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
-      - run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
-      - run: mbx llvm-cov --codecov --output-path codecov.json
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          files: codecov.json
+      - name: Check selected workflow result
+        env:
+          TRUSTED_RESULT: ${{ needs.trusted.result }}
+          UNTRUSTED_RESULT: ${{ needs.untrusted.result }}
+        run: |
+          if [[ "$TRUSTED_RESULT" == success && "$UNTRUSTED_RESULT" == skipped ]] ||
+             [[ "$TRUSTED_RESULT" == skipped && "$UNTRUSTED_RESULT" == success ]]; then
+            exit 0
+          fi
+          echo "trusted=$TRUSTED_RESULT untrusted=$UNTRUSTED_RESULT"
+          exit 1


### PR DESCRIPTION
## Summary

- cap untrusted CI at `contents: read`, so it cannot mint GitHub OIDC tokens
- grant `id-token: write` only to trusted runs initiated by `jdx`
- keep non-jdx and fork runs on GitHub-hosted runners with the GitHub cache backend
- preserve an explicit `ci` fan-in check

This follows up #281.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions trust boundaries and OIDC permissions; misconfigured `if` conditions could skip CI or leave untrusted jobs with excess permissions, but scope is workflow-only.
> 
> **Overview**
> CI is split so **trusted** runs (actor `jdx`, same-repo non-fork PRs) and **untrusted** runs (everyone else / fork PRs) each invoke a shared **`ci-impl`** reusable workflow, with OIDC limited to the trusted path.
> 
> The **`trusted`** job keeps **`contents: read`** and **`id-token: write`** (and inherits secrets); **`untrusted`** calls the same implementation with **`contents: read` only**, so those runs cannot mint OIDC tokens for the mbx cache. A lightweight **`ci`** fan-in job still requires exactly one of the two paths to succeed and the other to be skipped.
> 
> The **`mbx`** composite action’s cache **backend** expression now also routes non-`jdx` actors to the GitHub cache (not only fork PRs), aligning cache behavior with the trust split while trusted runs can still use the jdx server backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9221d59a59a9fdf99e6d081ba5250af912ec20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Added reusable continuous integration and coverage workflows.
  * Improved validation for trusted and untrusted execution contexts.
  * Added automated linting, testing, rendering-diff checks, security auditing, and coverage reporting.
  * Strengthened workflow permissions and credential handling for safer builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->