### PR TITLE
security(ci): avoid inheriting workflow secrets

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -3,14 +3,9 @@ name: CI implementation
 on:
   workflow_call:
 
-permissions: {}
-
 jobs:
   ci:
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -34,9 +29,6 @@ jobs:
 
   coverage:
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/ci-impl.yml
-    secrets: inherit
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}


### PR DESCRIPTION
## Summary

- stop forwarding the repository secret set into the reusable CI workflow
- keep the structural OIDC boundary from #282 without triggering zizmor’s `secrets-inherit` finding

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only hardening with no application code changes; verify trusted runners still get OIDC if codecov or custom runners require it.
> 
> **Overview**
> Tightens CI secret exposure by **removing `secrets: inherit`** from the trusted job that calls the reusable `ci-impl` workflow, so the implementation no longer receives the full repository secret set.
> 
> **Permission boundaries move to the caller:** `ci-impl` no longer declares workflow- or job-level `permissions` (including `id-token: write`). The existing **trusted vs untrusted** split in `ci.yml` still grants `contents: read` plus `id-token: write` only on trusted runs, and `contents: read` only on untrusted runs—preserving the OIDC gate from #282 while satisfying zizmor’s `secrets-inherit` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1da347ed2a7deee81f991804576c5cf58b41b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->