### PR TITLE
ci: seed mbx cache for fork PRs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,20 @@
 name: Set up mbx
 description: Select the trusted jdx server or fork-safe GitHub cache backend
 
+inputs:
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
+
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
+      with:
+        version: 0.4.0
+        backend: github
     - uses: jdx/mr-boxington-action@2bbb8f141e40e388b509cc68fe0bfbe7bc4b6818 # v1
       with:
         version: 0.4.0

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)


### PR DESCRIPTION
## Summary

- restore the fork-facing GitHub Actions mbx cache in one canonical CI job per supported OS
- keep the trusted server backend active for compilation, then save the updated local store under the exact key format fork PRs restore
- restrict mirror writes to jdx pushes on main; fork and other untrusted PR runs remain restore-only and OIDC-free

## Validation

- actionlint
- high-severity zizmor audit
- git diff check
- confirmed release workflows do not enable the mirror

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with mirror writes gated to trusted main pushes; no application or auth logic changes.
> 
> **Overview**
> Adds an optional **`mirror-github-cache`** input to the composite **mbx** setup action. When enabled, a **restore-only** `mr-boxington-action` step with the **GitHub** backend runs **before** the existing mbx step, but **only** on **`jdx` pushes to `main`**, so trusted main builds can populate the same cache keys fork PRs read.
> 
> The reusable **CI implementation** workflow turns this on for the primary **`ci`** job only (`mirror-github-cache: "true"`). The **coverage** job and other callers keep the default (**off**). Trusted runs still use the **server** backend for compilation where applicable; fork/untrusted PR flows stay **GitHub restore-only** and unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6f58e1fa2aeb7e834f43ed0c9987ffce37a008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an optional GitHub cache-mirroring capability for trusted builds.
  - Enabled cache mirroring in the continuous integration workflow to improve cache availability and build consistency.
  - The capability is disabled by default and can be enabled when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->