### PR TITLE
v1.3.4: Dev Tooling Maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.3.4](https://github.com/jdx/communique/releases/tag/v1.3.4) - 2026-09-01
+
+## Changed
+
+- Release workflow now fails closed when notarization credentials are missing, preventing signed-but-unnotarized macOS binaries from shipping ([#296](https://github.com/jdx/communique/pull/296))
+- Tightened the sponsor message appended to GitHub release notes ([#300](https://github.com/jdx/communique/pull/300))
+
+_Otherwise a maintenance release: CI hardening, `mbx`/`mr-boxington` tooling updates, and dependency bumps (`log` 0.4.34, `usage` 6.6.1, `mise-action` 4.3.0)._
+
 ## [1.3.2](https://github.com/jdx/communique/releases/tag/v1.3.2) - 2026-08-22
 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "clx",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name communique
 bin communique
-version "1.3.3"
+version "1.3.4"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 unknown_flags error

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -456,7 +456,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.3.3",
+  "version": "1.3.4",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `communique [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.3.3
+**Version:** 1.3.4
 
 - **Usage:** `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A maintenance-only release. There are no changes to the communique CLI itself — this cycle is entirely CI/CD, release-workflow hardening, dependency bumps, and updates to the `mbx`/`mr-boxington` build tooling.

The two changes with any external visibility are release-process safeguards rather than runtime behavior:

## Changed

- The release workflow now **fails closed** when notarization credentials are missing: the macOS release job requires all App Store Connect credentials and aborts if any resolve to an empty value, so releases can no longer silently publish signed-but-unnotarized binaries. ([#296](https://github.com/jdx/communique/pull/296)) (@jdx)
- Refreshed the sponsor message appended to GitHub release notes with tighter wording and a direct link to the individual/company sponsor page. ([#300](https://github.com/jdx/communique/pull/300)) (@jdx)

## 💚 Sponsor communique

communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.

If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic or CI workflow edits in the diff.
> 
> **Overview**
> **Cuts release v1.3.4** by bumping the package version from `1.3.3` to `1.3.4` in `Cargo.toml`, `Cargo.lock`, the generated usage spec (`communique.usage.kdl`), and CLI docs (`docs/cli/commands.json`, `docs/cli/index.md`).
> 
> **Updates `CHANGELOG.md`** with a `1.3.4` (2026-09-01) section that records release-process changes already merged elsewhere: macOS release workflow **fails closed** when App Store Connect notarization credentials are missing ([#296](https://github.com/jdx/communique/pull/296)), and a **tighter sponsor blurb** on GitHub release notes ([#300](https://github.com/jdx/communique/pull/300)), plus a one-line note that the rest is maintenance (CI, `mbx`/`mr-boxington`, dependency bumps). This PR diff does not include workflow or runtime code—only versioning and changelog text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4469e335a638a4eb129ed563a69050928905d8f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->