### PR TITLE
chore(ci): adopt mbx 0.5.4

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -13,11 +13,11 @@ runs:
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
       with:
-        version: 0.5.3
+        version: 0.5.4
         backend: github
     - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
       with:
-        version: 0.5.3
+        version: 0.5.4
         backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique

--- a/mise.lock
+++ b/mise.lock
@@ -3,45 +3,45 @@
 lockfile_version = 1
 
 [[tools."github:jdx/mr-boxington"]]
-version = "0.5.3"
+version = "0.5.4"
 backend = "github:jdx/mr-boxington"
 specifiers = ["latest"]
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64"]
-checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-arm64-musl"]
-checksum = "sha256:05b465304902e9a37d3345623b89673e34a76ec960ddd2a623b3b4adc57ebdee"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059747"
+checksum = "sha256:e34adc416bb508f2ce9893b1bfc37baf648cf37633f22ec2056313b134a8b8bf"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135048"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools."github:jdx/mr-boxington"."platforms.linux-x64-musl"]
-checksum = "sha256:ba20120238687571e1cd8649c336ae278dbbf3b4acf560b75d43351b7de06635"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059753"
+checksum = "sha256:e63b7b1c1a628da767a7f6acd8c8a359c4a3266bc8dbad633983b6320861a8b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135059"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.macos-arm64"]
-checksum = "sha256:f29a17bd8242f140d2ffdff26116b0433d70073e89b8b602da47931ee7184ab6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059748"
+checksum = "sha256:290e5400fb0626331e5216a51384a6dfe11c0e05817e3bc9f54aa471c38ddf14"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135050"
 provenance = "github-attestations"
 
 [tools."github:jdx/mr-boxington"."platforms.windows-x64"]
-checksum = "sha256:5baf59eed06b711f2e363e52009953d03bb00bc03b25cdd73c318c061d518a1d"
-url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.3/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533059746"
+checksum = "sha256:54f05f2b7da4b6b3570c1867d2ba5c4ce9c17732bd9199adab138a6914c8ff2e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v0.5.4/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/533135049"
 provenance = "github-attestations"
 
 [[tools.hk]]


### PR DESCRIPTION
## Summary

- update the composite CI wrapper to install mbx 0.5.4
- refresh `mise.lock` URLs, checksums, asset IDs, and GitHub attestation provenance
- preserve the existing trusted-server and fork-safe GitHub cache routing

mbx 0.5.4 includes the persistent compiler-shim fix needed by builds that retain `HOST_CC` paths across sessions.

## Testing

- `mise lock --bump --minimum-release-age 0 github:jdx/mr-boxington`
- locked Linux install reports `mbx 0.5.4`
- `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and CI tooling version bump only; no application logic or auth changes.
> 
> **Overview**
> Bumps **mbx** (`github:jdx/mr-boxington`) from **0.5.3** to **0.5.4** for CI and local `mise` installs.
> 
> The composite **Set up mbx** action now passes `version: 0.5.4` for both the fork cache-mirror step and the main setup step; trusted-server vs fork-safe GitHub cache routing is unchanged. **`mise.lock`** is refreshed with the new release URLs, checksums, and GitHub asset IDs for all platforms.
> 
> This picks up **0.5.4**’s persistent compiler-shim fix for builds that keep `HOST_CC` paths across cache sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0ef188ec10ee701e633f080a2677dff1869058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated cache handling to the latest action version.
  - Improved cache restoration by explicitly selecting the GitHub backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->