### PR TITLE
fix(ci): suppress unreleased mbx action tag audit

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,11 +11,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
+      uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # zizmor: ignore[ref-version-mismatch] unreleased commit
       with:
         version: 0.5.3
         backend: github
-    - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # v1
+    - uses: jdx/mr-boxington-action@d311086f3b4337b7ad305330ff77ea716d372fc1 # zizmor: ignore[ref-version-mismatch] unreleased commit
       with:
         version: 0.5.3
         backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}


### PR DESCRIPTION
## Summary

- retain the full-SHA pin for the unreleased `mr-boxington-action` commit used by mbx 0.5.3
- suppress `ref-version-mismatch` at both call sites until that commit has a matching release tag
- remove the inaccurate `v1` comments that resolve to an older commit

## Tests

- `mise x zizmor@1.29.0 -- zizmor .`
- `mise run lint`

Fixes the failure in [GitHub Actions job 98726785111](https://github.com/jdx/communique/actions/runs/33133084757/job/98726785111).

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only CI audit suppression with no change to cache backend selection or action behavior.
> 
> **Overview**
> Updates the inline comments on both `jdx/mr-boxington-action` `uses` lines in the composite **mbx** action so **zizmor** stops failing on `ref-version-mismatch` while the workflow still pins an unreleased full SHA for mbx **0.5.3**.
> 
> The SHA pin and `version: 0.5.3` inputs are unchanged; only the misleading `# v1` notes are replaced with `zizmor: ignore[ref-version-mismatch]` until that commit has a matching release tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40974826d837b156514e7291581eebda15bc55fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->