### PR TITLE
chore(ci): update mr-boxington action pin

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,12 +14,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+      uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         backend: github
         cache-links: ${{ inputs.cache-links }}
-    - uses: jdx/mr-boxington-action@ccdc5852f8bd93375379830a75f24794407443df
+    - uses: jdx/mr-boxington-action@0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec
       with:
         version: 0.5.4
         cache-links: ${{ inputs.cache-links }}


### PR DESCRIPTION
Update `jdx/mr-boxington-action` to `0bb0a01e0b2b3f34db827eddc8307bd4b1fb48ec`, which scopes generated cache keys by Rust compiler identity.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change with no application or auth logic changes; main effect is cache key behavior for builds.
> 
> **Overview**
> Updates the **`jdx/mr-boxington-action`** commit pin in the composite **`mbx`** setup action (fork PR cache mirror step and main cache step) from `ccdc5852…` to **`0bb0a01e…`**, while keeping **`version: 0.5.4`** and all existing backend/OIDC/server settings unchanged.
> 
> The new action revision is intended to **scope generated cache keys by Rust compiler identity**, so CI caches stay aligned with the toolchain actually building the project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac710773625d0648d7f88a81a77e584e8ba9ccf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->