### PR TITLE
ci: back mbx with the GitHub Actions cache alone

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,10 +1,7 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Set up mbx with the GitHub Actions cache backend
 
 inputs:
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
   cache-links:
     description: Cache native links; "auto" enables this on Linux
     default: auto
@@ -15,20 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && github.actor == 'jdx' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
+    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
       with:
         version: 0.6.0
         backend: github
         cache-links: ${{ inputs.cache-links }}
         toolchain: ${{ inputs.toolchain }}
-    - uses: jdx/mr-boxington-action@906ad32aec2915c312aceb21c2354cc8c0548f5f
-      with:
-        version: 0.6.0
-        cache-links: ${{ inputs.cache-links }}
-        toolchain: ${{ inputs.toolchain }}
-        backend: ${{ (github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server' }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/communique
-        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -11,8 +11,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
-        with:
-          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)


### PR DESCRIPTION
Retires the remote cache server from CI: every job now uses mbx's GitHub Actions cache backend. Removes the backend-selection expression, the `mbx-backend` workflow plumbing, the fork-PR cache mirror, and the server-warming workflow — all of which existed to route trusted builds at cache.mise.jdx.dev. mbx itself stays.

`id-token: write` grants are left in place where they may serve Pages deploys or attestations; they can be tightened separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect CI build-cache wiring; no application runtime, auth, or data paths are modified, though cache hit rates and build times may shift (especially for fork PRs).
> 
> **Overview**
> **CI caching is simplified:** mbx always uses the **GitHub Actions** `backend` instead of switching between `cache.mise.jdx.dev` and GitHub based on actor, event, or fork status.
> 
> The composite **`.github/actions/mbx`** action drops the `mirror-github-cache` input and the conditional “fork PR cache mirror” step, plus `server-url`, `namespace`, and `oidc-audience` for the remote server. **`ci-impl.yml`** no longer passes `mirror-github-cache: "true"` when setting up mbx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745f811bb3edef93d726db290904ac0626cb8fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->