### PR TITLE
chore(ci): fail closed without notarization credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ on:
       CERTIFICATES_P12_PASS:
         required: true
       APPLE_API_KEY_P8:
-        required: false
+        required: true
       APPLE_API_KEY_ID:
-        required: false
+        required: true
       APPLE_API_ISSUER_ID:
-        required: false
+        required: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -95,8 +95,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "$APPLE_API_KEY_P8" ] || [ -z "$APPLE_API_KEY_ID" ] || [ -z "$APPLE_API_ISSUER_ID" ]; then
-            echo "::warning title=Not notarized::App Store Connect credentials are unset, so this release ships signed but un-notarized macOS binaries. Gatekeeper will block them for anyone who downloads an archive through a browser."
-            exit 0
+            echo "::error title=Notarization credentials missing::App Store Connect credentials are required for macOS releases."
+            exit 1
           fi
 
           # Outside the workspace, so no later step can sweep the key into an


### PR DESCRIPTION
## Summary
- require all App Store Connect credentials in the reusable release workflow
- fail the macOS release job if any credential resolves to an empty value
- prevent releases from silently publishing signed but unnotarized binaries

## Testing
- `actionlint .github/workflows/release.yml`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS releases now require all App Store Connect credentials for notarization.
  * Release workflows fail clearly when notarization credentials are missing, preventing distribution of signed but un-notarized binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->