### PR TITLE
chore: update mr-boxington to 1.3.0

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -6,6 +6,6 @@ runs:
   steps:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
-        version: 1.1.0
+        version: 1.3.0
         backend: github
         cache-generation: v2

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -24,7 +24,7 @@ jobs:
             exit 1
           fi
       - run: mise run lint
-      - run: mbx test
+      - run: cargo test
       - run: cargo audit
 
   coverage:
@@ -37,7 +37,7 @@ jobs:
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
-      - run: mbx llvm-cov --codecov --output-path codecov.json
+      - run: cargo llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: codecov.json

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -104,6 +104,8 @@ jobs:
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           persist-credentials: false
+      - uses: ./.github/actions/mbx
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Enhance GitHub release with communique
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
-compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
+`mise install` installs mbx 1.3. `mise run` activates the project's transparent
+Cargo wrapper, so compilation-heavy mise tasks and hk checks use ordinary
+`cargo` commands. Standalone Cargo commands require an activated mise shell. If
 the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,15 @@
 
 ## mbx build cache
 
-Mise installs mbx 1.1 and activates its transparent Cargo shim, so
+Mise installs mbx 1.3 and activates its transparent Cargo wrapper, so
 compilation-heavy mise tasks and hk checks use ordinary `cargo` commands. If
-the shim fails or creates a development papercut, rerun the exact equivalent
+the wrapper fails or creates a development papercut, rerun the exact equivalent
 command from `CONTRIBUTING.md` with `MBX_DISABLE=1`; this unblocks work without
 weakening the check. If bypassed Cargo succeeds, surface the mismatch and recommend a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions) with
 the repository and commit, OS, `mbx --version`, `mbx doctor`, and both commands
 and outputs. Redact secrets, absolute cache paths, remote URLs, namespaces, and
-other sensitive or identifying details. Do not permanently disable the shim,
+other sensitive or identifying details. Do not permanently disable the wrapper,
 and do not post externally without user authorization.
 
 ## Dependency Updates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ See the [contributing guide](https://communique.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
-its transparent Cargo wrapper. The normal `mise run build` and `mise run lint`
-workflows therefore use the cache while invoking Cargo normally. To bypass mbx
-without skipping or weakening a check, prefix the equivalent Cargo command
-with `MBX_DISABLE=1`:
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3. The normal
+`mise run build` and `mise run lint` workflows activate its transparent Cargo
+wrapper and therefore use the cache while invoking Cargo normally. Standalone
+Cargo commands require an activated mise shell. To bypass mbx without skipping
+or weakening a check, prefix the equivalent Cargo command with `MBX_DISABLE=1`:
 
 ```sh
 MBX_DISABLE=1 cargo build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ See the [contributing guide](https://communique.jdx.dev/contributing).
 
 ## mbx build cache
 
-`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.1 and activates
-its transparent Cargo shim. The normal `mise run build` and `mise run lint`
+`mise install` installs [mbx](https://mr-boxington.jdx.dev) 1.3 and activates
+its transparent Cargo wrapper. The normal `mise run build` and `mise run lint`
 workflows therefore use the cache while invoking Cargo normally. To bypass mbx
 without skipping or weakening a check, prefix the equivalent Cargo command
 with `MBX_DISABLE=1`:
@@ -16,7 +16,7 @@ MBX_DISABLE=1 cargo test
 MBX_DISABLE=1 cargo clippy --manifest-path Cargo.toml --quiet -- -D warnings
 ```
 
-If bypassed Cargo succeeds where the shim fails, or mbx introduces a papercut, please start a
+If bypassed Cargo succeeds where the wrapper fails, or mbx introduces a papercut, please start a
 [mr-boxington Discussion](https://github.com/jdx/mr-boxington/discussions).
 Include the repository and commit, operating system, `mbx --version`,
 `mbx doctor`, and both commands and their output. Before posting, redact

--- a/mise.lock
+++ b/mise.lock
@@ -38,45 +38,45 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.1.0"
+version = "1.3.0"
 backend = "github:jdx/mr-boxington"
-specifiers = ["1.1.0"]
+specifiers = ["1.3.0"]
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:ded60221f2217a6e0abfe0ba3583674bae63e5a7b696c4fa145827a3a0e352af"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232514"
+checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:70a882277389bd6e6b606fc291083a857a7ef0c742b60ba5a7822cc49fe7c4ac"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232511"
+checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:8e718ff25e71057f758d02f3039481258cd531be914afd3f77198811d0113a74"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232519"
+checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:9f590a0fd0fc0a5896791257863980fe9c6035458414575749cc43e68e7ff0cf"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232518"
+checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:da96661534480fff35ec78e598124d208ac1f2624c6d3c287c9ae2a5852b0b29"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232513"
+checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:4adbb02bf97f00644d2e1e3930e154df39a07df1e574e0829b5d6e34474a3c95"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.1.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/537232517"
+checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
 provenance = "github-attestations"
 
 [[tools.pkl]]

--- a/mise.toml
+++ b/mise.toml
@@ -26,8 +26,12 @@ run = "npm i && exec npm run docs:dev"
 
 # rust is managed by rustup, not mise
 [tools]
-mr-boxington = { version = "1.1.0", postinstall = "mbx setup --global" }
+mr-boxington = "1.3.0"
 usage = "6.4.0"
 hk = "latest"
 pkl = "latest"
 ripgrep = "latest"
+
+[wrappers.cargo]
+command = "mbx"
+env = { MBX_CARGO_SHIM_MODE = "1" }

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.8.16"
+
 [env]
 _.path = "target/debug"
 


### PR DESCRIPTION
## Summary
- update mr-boxington to 1.3.0 and refresh its lock entry
- commit the project-scoped Cargo wrapper instead of running global setup
- update mbx contributor and agent guidance for command wrappers

## Validation
- `mise lock --dry-run --json mr-boxington`
- verified `mbx 1.3.0` and Cargo resolution through mise command wrappers

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI wiring only; no application runtime or security-sensitive logic changes, with modest risk if the new wrapper misbehaves in CI or release builds.
> 
> **Overview**
> Bumps **mbx** (mr-boxington) from **1.1.0** to **1.3.0** across the GitHub composite action, `mise.toml`, and `mise.lock`, and raises **mise** `min_version` to **2026.8.16** for wrapper support.
> 
> Caching is wired through a **project-scoped `[wrappers.cargo]`** that runs `mbx` with `MBX_CARGO_SHIM_MODE=1`, replacing the old **`mbx setup --global` postinstall**. CI and release jobs now invoke plain **`cargo test`** and **`cargo llvm-cov`** (still cached when mise is active); the **enhance-release** workflow adds **mbx + mise** setup before **`cargo build`**.
> 
> **AGENTS.md** and **CONTRIBUTING.md** document 1.3, the Cargo wrapper, and that bare `cargo` needs an activated mise shell; troubleshooting text refers to the wrapper instead of a global shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d408fc730c61d5f27e654787db0f5fc12eee53ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mbx setup and troubleshooting guidance for version 1.3.
  * Clarified Cargo wrapper activation and requirements for standalone Cargo commands.

* **Configuration**
  * Updated the configured mbx tool to version 1.3.0.
  * Configured Cargo commands to run through the wrapper automatically.
  * Removed the mbx post-install step and set a minimum mise version.

* **CI/CD**
  * Updated automated testing, coverage, and release workflows to use the revised tooling setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->