### PR TITLE
ci: use mbx server cache for trusted builds

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -5,10 +5,20 @@ inputs:
   backend:
     description: Backend selected by the structurally trusted caller
     default: github
+  mirror-github-cache:
+    description: Mirror a trusted main build into the restore-only cache used by fork PRs
+    default: "false"
 
 runs:
   using: composite
   steps:
+    - name: Restore the fork PR cache mirror
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      with:
+        version: 1.3.0
+        backend: github
+        cache-generation: v2
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -3,8 +3,8 @@ description: Select the trusted jdx server or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Explicit backend for structurally trusted or untrusted callers
-    default: auto
+    description: Backend selected by the structurally trusted caller
+    default: github
 
 runs:
   using: composite
@@ -13,7 +13,7 @@ runs:
       with:
         version: 1.3.0
         cache-generation: v2
-        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev
         namespace: jdx/communique
         oidc-audience: https://cache.mise.jdx.dev

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,5 +1,10 @@
 name: Set up mbx
-description: Set up mbx with the GitHub Actions cache backend
+description: Select the trusted jdx server or fork-safe GitHub cache backend
+
+inputs:
+  backend:
+    description: Explicit backend for structurally trusted or untrusted callers
+    default: auto
 
 runs:
   using: composite
@@ -7,5 +12,8 @@ runs:
     - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
       with:
         version: 1.3.0
-        backend: github
         cache-generation: v2
+        backend: ${{ inputs.backend != 'auto' && inputs.backend || ((github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx'))) && 'github' || 'server') }}
+        server-url: https://cache.mise.jdx.dev
+        namespace: jdx/communique
+        oidc-audience: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
+          mirror-github-cache: "true"
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -2,6 +2,10 @@ name: CI implementation
 
 on:
   workflow_call:
+    inputs:
+      trusted:
+        required: true
+        type: boolean
 
 jobs:
   ci:
@@ -11,6 +15,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
@@ -34,6 +40,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: ${{ inputs.trusted && 'server' || 'github' }}
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,16 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: true
 
   untrusted:
     if: ${{ github.actor != 'jdx' || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx')) }}
     permissions:
       contents: read
     uses: ./.github/workflows/ci-impl.yml
+    with:
+      trusted: false
 
   ci:
     name: ci

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -99,6 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -106,6 +106,8 @@ jobs:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           persist-credentials: false
       - uses: ./.github/actions/mbx
+        with:
+          backend: server
       - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
       - name: Enhance GitHub release with communique
         env:


### PR DESCRIPTION
## Summary

- route trusted jdx builds through cache.mise.jdx.dev with OIDC
- retain the GitHub Actions cache backend for forks and untrusted callers
- isolate cache entries under the repository namespace

## Validation

- actionlint -shellcheck= .github/workflows/*.yml
- git diff --check

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions cache wiring and OIDC permissions on already-gated trusted jobs; application runtime and secrets handling are unchanged.
> 
> **Overview**
> **Trusted CI and release jobs** now point the `mbx` composite action at `cache.mise.jdx.dev` via OIDC (`backend: server`, `jdx/communique` namespace). **Fork and untrusted PR paths** keep the GitHub Actions cache backend only.
> 
> The `mbx` action gains **`backend`** and **`mirror-github-cache`** inputs: on trusted **main pushes**, an extra restore-only GitHub cache step can seed the fork PR cache while the primary step uses the selected backend.
> 
> **`ci-impl.yml`** accepts a required **`trusted`** boolean; **`ci.yml`** passes `trusted: true` or `false` from existing trusted/untrusted job split (trusted job also gets `id-token: write`). **`enhance-release`** in release-plz uses the server backend and adds **`id-token: write`** for OIDC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae4a15ffda6b8a2163e4a86c5564dd068ca423d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable cache backend selection, including automatic selection based on execution context.
  - Added support for custom server URLs, namespaces, and OIDC audiences.

- **Chores**
  - Enabled secure OIDC token issuance for release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->