### PR TITLE
chore(release): improve sponsor message

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -130,9 +130,9 @@ jobs:
 
           ## 💚 Sponsor communique
 
-          communique is maintained by [@jdx](https://github.com/jdx), an open source developer for [**entire.io**](https://entire.io), the title sponsor of the [jdx.dev](https://jdx.dev) open source tools including [mise](https://mise.jdx.dev/), [aube](https://aube.jdx.dev/), hk, and more. Ongoing work on communique is funded by sponsorships.
+          communique is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.
 
-          If communique is drafting your release notes or changelogs, please consider [sponsoring at jdx.dev](https://jdx.dev/sponsors.html). Every sponsor — individual or company — helps keep the project independent and actively maintained.
+          If communique drafts your release notes or changelogs, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep communique fast, free, and independent.
           EOF
 
           gh release edit "$TAG" --notes-file /tmp/release-notes.md


### PR DESCRIPTION
## Summary

- clarify Entire's sponsorship of jdx's open source work
- link the sponsorship call to action directly to the individual and company sponsor page
- tighten the release-note copy while preserving each CLI's tailored message

## Testing

- git diff --check
- parsed the updated workflow as YAML

*AI-assisted — Tool: Codex; model: unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style text in a release-notes append step only; no runtime or security impact.
> 
> **Overview**
> **Updates the sponsor blurb** that the `enhance-release` job appends to GitHub release notes after communique runs (same strip-and-reappend flow via `gh release edit`).
> 
> The **## 💚 Sponsor communique** copy is tightened: Entire is described as employing [@jdx](https://github.com/jdx) and title-sponsoring his open source work (dropping the long list of jdx.dev tools and the separate “funded by sponsorships” line). The CTA now points readers to become an **[individual or company sponsor](https://jdx.dev/sponsors.html)** and emphasizes support keeping communique fast, free, and independent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2cfcd8b06eb2728ad99ee0cc30b6da58bcf53d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sponsor message included in GitHub release notes with refreshed wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->