### PR TITLE
chore(ci): update mbx to 1.3.2

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@v1.2.0
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@v1.2.0
+    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,11 +14,11 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+      uses: jdx/mr-boxington-action@v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
+    - uses: jdx/mr-boxington-action@v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -14,14 +14,12 @@ runs:
   steps:
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+      uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@203ebddb3bdb1b3832473207d0a837b23b660563
+    - uses: jdx/mr-boxington-action@b296cd252864fce4f84642a2e0062d54621d5b41
       with:
-        version: 1.3.0
         cache-generation: v2
         backend: ${{ inputs.backend }}
         server-url: https://cache.mise.jdx.dev

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
           mirror-github-cache: "true"
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
       - run: mise run render
@@ -46,10 +46,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'server' || 'github' }}
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - run: cargo llvm-cov --codecov --output-path codecov.json

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -105,10 +105,10 @@ jobs:
         with:
           ref: refs/tags/${{ needs.release-plz-release.outputs.tag }}
           persist-credentials: false
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
           backend: server
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Enhance GitHub release with communique
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/mise.lock
+++ b/mise.lock
@@ -38,45 +38,45 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.3.0"
+version = "1.3.2"
 backend = "github:jdx/mr-boxington"
-specifiers = ["1.3.0"]
+specifiers = ["1.3.2"]
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:92a8544d26324b7803eeb1d2f1c276e322e474d45e7f40b6f6a1e72ce99d6fdc"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561463"
+checksum = "sha256:18aabfdfaced4316b9e9fd488d65df0915b241aa3af8e761b4df0fc0bdc1a4f7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849887"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:db505d360e8c1dfc6fb31ecf8172329ae2fa2417b14508e306626c6c1dba3514"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561466"
+checksum = "sha256:abbbcc8cc7c080febc5f6c77e1ae7af89faf15476248282f7bf4c331e836ee1b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849885"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:0717a7dc93fdd9712d648ddab0f7e0871b50b626568c62a5c1033396f50e3940"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561483"
+checksum = "sha256:6096035ae9bb47d718b7c0ca2860e1142047ebf724b37c02d3a520a4b9804d2d"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849911"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:385b25699ba7429fe7cd36668667c45ff8d38f4491ebb4164e95021b22374ed0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561484"
+checksum = "sha256:a31a332095ac291686777736d450b2f62658145ac173ff543f83271e44850df7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849909"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:0d2e9d6e7d8228faafda68e2cd4190ce977a332821833c19a853c4a9dd91a82f"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561462"
+checksum = "sha256:3a91ecb2d6ff4ad84662e79599d11e79eff4738c222a35ed432db4b15ade4d1e"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849886"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:e102e3e1dd0777fc7a39c91a7805cbc8636bc4ab0c5cdc30a51b7962b8a524a7"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.0/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/538561482"
+checksum = "sha256:49e3a4570034612fd7b193e4f56830bdece32c73ac92eb7f0d580c85695492df"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.3.2/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/539849907"
 provenance = "github-attestations"
 
 [[tools.pkl]]

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ run = "npm i && exec npm run docs:dev"
 
 # rust is managed by rustup, not mise
 [tools]
-mr-boxington = "1.3.0"
+mr-boxington = "1.3.2"
 usage = "6.6.1"
 hk = "latest"
 pkl = "latest"


### PR DESCRIPTION
## Summary

- use mr-boxington-action v1.2.0, pinned to its release commit
- use the project-installed mbx instead of installing a separate copy in CI
- update the project mbx pin and lockfile to 1.3.2
- keep explicit benchmark or specialized workflow installs on mbx 1.3.2 where applicable

## Validation

- mise lock mr-boxington
- git diff --check
- GitHub Actions

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved consistency across automated build, coverage, and release workflows.
  * Added safeguards to prevent overlapping runs and limit job execution time.
  * Updated automation tooling, including the configured automation and usage tools.
  * Reordered environment setup so required tooling is prepared before subsequent automation runs.
  * Updated the reusable automation action to the latest approved release.
  * Preserved existing backend, cache, and server configuration across affected workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and developer-tooling pins only; no application runtime or auth logic changes.
> 
> **Overview**
> Bumps **mr-boxington** (`mbx`) from **1.3.0** to **1.3.2** in `mise.toml` and regenerates `mise.lock` with new download URLs and checksums.
> 
> Updates the reusable **`.github/actions/mbx`** composite to **`jdx/mr-boxington-action` v1.2.0** (pinned commit) and **drops the `version` input** on both cache steps so the action uses the **mise-installed** `mbx` instead of fetching a separate binary.
> 
> In **CI** (`ci-impl.yml`) and **release enhancement** (`release-plz.yml`), **`jdx/mise-action` now runs before** `./.github/actions/mbx` so tooling from the lockfile is on PATH when cache setup runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32621c3ea0e82b0803e80776becdfb19c722e05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->