### PR TITLE
fix(ci): cancel stale jobs and bound runtimes

### DIFF
--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -7,9 +7,14 @@ on:
         required: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -36,6 +41,7 @@ jobs:
 
   coverage:
     runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     permissions: {}
     needs: [trusted, untrusted]
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - name: Check selected workflow result
         env:


### PR DESCRIPTION
## Summary
- cancel superseded CI runs for the same ref
- cap the CI and coverage jobs at 30 minutes
- cap the final status job at 1 minute

## Why
Two recent PR runs left both Namespace jobs active for the full six-hour default before cancellation. Normal successful jobs complete well within the new limits.

## Validation
- actionlint .github/workflows/ci.yml .github/workflows/ci-impl.yml
- zizmor .github/workflows/ci.yml .github/workflows/ci-impl.yml

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application code, auth, or data handling impact.
> 
> **Overview**
> **Adds workflow concurrency** on the reusable CI implementation so a new run on the same ref cancels any still-running previous run (`cancel-in-progress: true`), avoiding long-lived duplicate Namespace jobs.
> 
> **Adds job timeouts**: 30 minutes on the main `ci` and `coverage` jobs in `ci-impl.yml`, and 1 minute on the top-level `ci` gate job in `ci.yml` that checks trusted vs untrusted results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649010945094368afee4b30db7831abe83217304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->