### PR TITLE
ci: use shared Namespace volume for local mbx caching

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up mise for the local mbx install
+      if: inputs.backend == 'local'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
@@ -20,7 +26,8 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+      run:
+        | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,6 +12,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Mount the local mbx store on the Namespace cache volume
+      if: inputs.backend == 'local'
+      uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
+    - name: Install mbx for local caching
+      if: inputs.backend == 'local'
+      shell: bash
+      run: |
+        mise install mr-boxington
+        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
+        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
+        fi
     - name: Restore the fork PR cache mirror
       if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Install mbx for local caching
       if: inputs.backend == 'local'
       shell: bash
-      run: |
+      run: | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,9 +1,9 @@
 name: Set up mbx
-description: Select the trusted jdx server or fork-safe GitHub cache backend
+description: Use the local Namespace volume or fork-safe GitHub cache backend
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller
+    description: Backend selected by the structurally trusted caller; local skips transport
     default: github
   mirror-github-cache:
     description: Mirror a trusted main build into the restore-only cache used by fork PRs
@@ -13,12 +13,13 @@ runs:
   using: composite
   steps:
     - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'server' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         backend: github
         cache-generation: v2
-    - uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
+    - if: inputs.backend != 'local'
+      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
       with:
         cache-generation: v2
         backend: ${{ inputs.backend }}

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
           mirror-github-cache: "true"
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
@@ -49,7 +49,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'server' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'github' }}
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - run: cargo llvm-cov --codecov --output-path codecov.json

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -40,7 +40,7 @@ jobs:
       - run: cargo audit
 
   coverage:
-    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64' }}
+    runs-on: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login != 'jdx') && 'ubuntu-latest' || 'namespace-profile-endev-linux-amd64;overrides.cache-tag=cache' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     if: ${{ github.actor == 'jdx' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login == 'jdx')) }}
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/ci-impl.yml
     with:
       trusted: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v3.0.2-node.24


### PR DESCRIPTION
Keep Mr Boxington as the local build cacher for ordinary trusted Namespace jobs, using the shared Namespace volume selected by `overrides.cache-tag=cache`.

Trusted jobs use the project `mbx` wrapper locally without GitHub-cache or remote-server transport. Untrusted jobs remain on GitHub-hosted runners with the GitHub cache backend.

Privileged release, signing, deployment, and architecture-specific release jobs retain their existing isolated or untagged runner profiles.

Validation: actionlint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions caching and runner configuration; application code and release signing paths are untouched aside from release-plz still using the server backend.
> 
> **Overview**
> Trusted **CI** and **coverage** jobs now use an **`local`** mbx backend instead of the remote **`server`** cache, with Namespace runners tagged via `overrides.cache-tag=cache` so mbx state lives on a shared volume.
> 
> The **mbx** composite action gains a **`local`** path: mount `~/.cache/mbx` with **nscloud-cache-action**, install **mr-boxington** via **mise**, clear **`MBX_REMOTE_URL`**, and skip **mr-boxington-action** transport; fork-cache mirroring on **main** pushes now runs in that local setup. Non-local backends still use **mr-boxington-action** unchanged.
> 
> The trusted workflow job drops **`id-token: write`** because OIDC to `cache.mise.jdx.dev` is no longer needed for those runs. **docs** workflow only updates the pinned comment on **deploy-pages**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7d2001d304cf07c1e314d5d572d94921f86754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD**
  * Improved caching for trusted CI and coverage runs.
  * Trusted runs now use a local build backend for faster execution.
  * Reduced permissions requested by trusted CI jobs.
  * Pinned documentation deployments to a specific GitHub Pages action version.
  * Added local cache support for eligible builds while preserving remote processing for other workflows.
  * Updated build automation to improve reliability and maintain consistent behavior across trusted and untrusted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->