### PR TITLE
ci: refresh local mbx wrapper

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -29,6 +29,7 @@ runs:
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
+        mise reshim -f
         echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
         echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
         if [[ "$RUNNER_OS" == Linux ]]; then


### PR DESCRIPTION
Run `mise reshim -f` after installing mr-boxington in the local cache setup action. This refreshes the configured Cargo wrapper so plain `cargo` invocations use mbx.

Follow-up to the late review feedback on the Namespace cache PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI install-step change with no runtime or security impact.
> 
> **Overview**
> After installing **mr-boxington** in the local mbx composite action, CI now runs **`mise reshim -f`** so mise regenerates shims/wrappers. That keeps plain **`cargo`** calls on the runner routed through mbx for local cache backends, addressing stale wrappers after install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8892b39e7cb9b1c16bdb200b2492c7fdc1073440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->