### PR TITLE
ci: stop exporting mbx cache tarballs

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -10,10 +10,17 @@ runs:
   using: composite
   steps:
     - name: Set up mise for the mbx install
+      if: runner.os != 'Windows'
+      uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      with:
+        install: false
+        cache: false
+    - name: Set up mise for the mbx install on Windows
+      if: runner.os == 'Windows'
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ format('{0}/mise-data', runner.tool_cache) }}
+        MISE_CACHE_DIR: ${{ format('{0}/mise-cache', runner.tool_cache) }}
       with:
         install: false
         cache: false
@@ -26,10 +33,12 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
+        if [[ "$RUNNER_OS" == Windows ]]; then
+          export MISE_DATA_DIR="$RUNNER_TOOL_CACHE/mise-data"
+          export MISE_CACHE_DIR="$RUNNER_TOOL_CACHE/mise-cache"
+        fi
         mise install mr-boxington
         mise reshim -f
         mise where mr-boxington >> "$GITHUB_PATH"

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -12,8 +12,8 @@ runs:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       env:
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -26,8 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
-        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
-        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.tool_cache) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.tool_cache) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -11,6 +11,9 @@ runs:
   steps:
     - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+      env:
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       with:
         install: false
         cache: false
@@ -23,6 +26,8 @@ runs:
       shell: bash
       env:
         MBX_BACKEND: ${{ inputs.backend }}
+        MISE_DATA_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-data', runner.temp) || env.MISE_DATA_DIR }}
+        MISE_CACHE_DIR: ${{ runner.os == 'Windows' && format('{0}/mise-cache', runner.temp) || env.MISE_CACHE_DIR }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -24,6 +24,8 @@ runs:
       with:
         install: false
         cache: false
+        env: false
+        add_shims_to_path: false
     - name: Mount the local mbx store on the Namespace cache volume
       if: inputs.backend == 'local'
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1

--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,19 +1,15 @@
 name: Set up mbx
-description: Use the local Namespace volume or fork-safe GitHub cache backend
+description: Install mbx with a local Namespace, remote server, or ephemeral store
 
 inputs:
   backend:
-    description: Backend selected by the structurally trusted caller; local skips transport
+    description: Store selected by the structurally trusted caller
     default: github
-  mirror-github-cache:
-    description: Mirror a trusted main build into the restore-only cache used by fork PRs
-    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Set up mise for the local mbx install
-      if: inputs.backend == 'local'
+    - name: Set up mise for the mbx install
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install: false
@@ -23,29 +19,22 @@ runs:
       uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/mbx' || '~/.cache/mbx' }}
-    - name: Install mbx for local caching
-      if: inputs.backend == 'local'
+    - name: Install and configure mbx
       shell: bash
+      env:
+        MBX_BACKEND: ${{ inputs.backend }}
       run:
         | # zizmor: ignore[github-env] mise where returns the trusted tool install directory
         mise install mr-boxington
         mise reshim -f
-        echo "$(mise where mr-boxington)" >> "$GITHUB_PATH"
-        echo "MBX_REMOTE_URL=" >> "$GITHUB_ENV"
-        if [[ "$RUNNER_OS" == Linux ]]; then
-          echo "MBX_CACHE_LINKS=1" >> "$GITHUB_ENV"
-        fi
-    - name: Restore the fork PR cache mirror
-      if: inputs.mirror-github-cache == 'true' && inputs.backend == 'local' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        backend: github
-        cache-generation: v2
-    - if: inputs.backend != 'local'
-      uses: jdx/mr-boxington-action@adc5c234c02592f7edd008bf81d5bc0e9584dc03 # v1.2.0
-      with:
-        cache-generation: v2
-        backend: ${{ inputs.backend }}
-        server-url: https://cache.mise.jdx.dev
-        namespace: jdx/communique
-        oidc-audience: https://cache.mise.jdx.dev
+        mise where mr-boxington >> "$GITHUB_PATH"
+        {
+          if [[ "$MBX_BACKEND" == server ]]; then
+            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_NAMESPACE=jdx/communique"
+            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+          fi
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            echo "MBX_CACHE_LINKS=1"
+          fi
+        } >> "$GITHUB_ENV"

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: ./.github/actions/mbx
         with:
           backend: ${{ inputs.trusted && 'local' || 'github' }}
-          mirror-github-cache: "true"
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
       - run: mise run render

--- a/mise.lock
+++ b/mise.lock
@@ -38,45 +38,45 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
-version = "1.4.1"
+version = "1.5.0"
 backend = "github:jdx/mr-boxington"
-specifiers = ["1.4.1"]
+specifiers = ["1.5.0"]
 
 [tools.mr-boxington."platforms.linux-arm64"]
-checksum = "sha256:7ca1deeb64ad22bd5ddc9f45c749c78d3eb32608562c363727de3f0c595df0f0"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505948"
+checksum = "sha256:3782db0c07a47334d01d426896e9f6af2480b311def2d0f0a3ab1327b57247b2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628921"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-arm64-musl"]
-checksum = "sha256:3113dfce87c8ee6d3485f7eb99f87ae130b9b9f2c73224720edf2cef7279b5d1"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505946"
+checksum = "sha256:95e189127cf22f6586b0e7337893896dfb18b2018c7226e60844955e237234b8"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628922"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.linux-x64"]
-checksum = "sha256:5bc7434333a941f664bbe73ae229edf6111c9fb5f771f959ca411a11358baf8a"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505965"
+checksum = "sha256:83a5f4cb83a62cf028256c482a9f579911cc0793f79f1c2c06b83291c5c723d0"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629161"
 provenance = "github-attestations"
 provenance_verified = true
 
 [tools.mr-boxington."platforms.linux-x64-musl"]
-checksum = "sha256:7277ceabefae1b444b39200c2cb944018a87da628ff77aa94291a8cc338546e6"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505964"
+checksum = "sha256:8ffd1ffc4b53ce10ed1d0271e24d9d264e843b7be3f0a076389c4475a16e4132"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629170"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.macos-arm64"]
-checksum = "sha256:57f1cac111d9972ad675aa80cbedf4c86b3423dfb11091383175db0f6341847e"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505945"
+checksum = "sha256:d88ebea6ebf1a5b8b4a51a440a91baeb1214fdea49a6013dfe9b56e4bd4a6c84"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541628925"
 provenance = "github-attestations"
 
 [tools.mr-boxington."platforms.windows-x64"]
-checksum = "sha256:346cb0405129bbca4f7a24fc916b036cfd806d497d52ba47fc8bb0a0531b4382"
-url = "https://github.com/jdx/mr-boxington/releases/download/v1.4.1/mbx-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/540505963"
+checksum = "sha256:970f974d3ee56b089c34a4b03fdb80dfcc0b260b3de950009a77240c9187a4c7"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.5.0/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/541629146"
 provenance = "github-attestations"
 
 [[tools.pkl]]

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ run = "npm i && exec npm run docs:dev"
 
 # rust is managed by rustup, not mise
 [tools]
-mr-boxington = "1.4.1"
+mr-boxington = "1.5.0"
 usage = "6.6.1"
 hk = "latest"
 pkl = "latest"


### PR DESCRIPTION
Keep mbx on the live Namespace cache volume without serializing the store through GitHub Actions Cache.

The composite now installs mbx directly with mise for every runner. Trusted Namespace jobs retain the mounted local store, explicit server jobs configure mbx remote environment variables directly, and GitHub-hosted/untrusted jobs use ephemeral local stores. The GitHub cache mirror and `jdx/mr-boxington-action` are removed, so no mbx cache tarball is created or uploaded.

Validation: YAML parse, ShellCheck, actionlint, git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI cache behavior changes across trusted, server, and fork/untrusted paths; misconfigured env could slow builds or miss remote cache, but application code and secrets handling are unchanged.
> 
> **Overview**
> CI stops serializing the mbx store through **GitHub Actions Cache** and the **`jdx/mr-boxington-action`**. The composite **`.github/actions/mbx`** now always installs **`mr-boxington`** with **mise**, mounts the Namespace volume only when `backend: local`, and writes remote settings to **`GITHUB_ENV`** when `backend: server` (as in release workflows).
> 
> The **`mirror-github-cache`** input and main-branch fork mirror step are removed; **`ci-impl.yml`** no longer passes that flag. Trusted jobs keep a live local store; untrusted/`github` jobs rely on ephemeral local storage instead of restore-only tarball mirrors. **Windows** runners get explicit **mise** data/cache dirs under **`runner.tool_cache`**. **`mr-boxington`** is bumped to **1.5.0** in **`mise.toml`** / **`mise.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e166bfec266de22cda2404aef99a303688cfb9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * mbx now supports direct setup for local storage, remote servers, and GitHub-backed or ephemeral stores.
  * Remote server settings are configured automatically for the selected environment.
  * Windows-specific environment and cache directories are configured during setup.
  * Linux environments now support cache linking.

* **Breaking Changes**
  * Removed the `mirror-github-cache` option and associated fork pull request cache-mirroring behavior.

* **Updates**
  * Updated the mbx tool to version 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->