### PR TITLE
ci: use Azure cache on GitHub runners

### DIFF
--- a/.github/actions/mbx/action.yml
+++ b/.github/actions/mbx/action.yml
@@ -1,10 +1,10 @@
 name: Set up mbx
-description: Install mbx with a local Namespace, remote server, or ephemeral store
+description: Install mbx with a local Namespace store or the GitHub Actions cache server
 
 inputs:
   backend:
-    description: Store selected by the structurally trusted caller
-    default: github
+    description: Use local on Namespace runners and server on GitHub-hosted runners
+    default: server
 
 runs:
   using: composite
@@ -46,9 +46,13 @@ runs:
         mise where mr-boxington >> "$GITHUB_PATH"
         {
           if [[ "$MBX_BACKEND" == server ]]; then
-            echo "MBX_REMOTE_URL=https://cache.mise.jdx.dev"
+            echo "MBX_REMOTE_URL=https://cache.jdx.dev"
             echo "MBX_REMOTE_NAMESPACE=jdx/communique"
-            echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.mise.jdx.dev"
+            if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+              echo "MBX_REMOTE_OIDC_AUDIENCE=https://cache.jdx.dev"
+            else
+              echo "::notice::GitHub OIDC is unavailable; using public read-only cache access" >&2
+            fi
           fi
           if [[ "$RUNNER_OS" == Linux ]]; then
             echo "MBX_CACHE_LINKS=1"

--- a/.github/workflows/ci-impl.yml
+++ b/.github/workflows/ci-impl.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - run: rustup component add clippy rustfmt
       - uses: taiki-e/install-action@c030abdc26abd91eb618a6c9d1963825f7ce5a90 # zizmor: ignore[impostor-commit] cargo-audit (tag-only ref by design)
       - run: mise run render
@@ -48,7 +48,7 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - uses: ./.github/actions/mbx
         with:
-          backend: ${{ inputs.trusted && 'local' || 'github' }}
+          backend: ${{ inputs.trusted && 'local' || 'server' }}
       - run: rustup component add llvm-tools-preview
       - uses: taiki-e/install-action@4c7e9f3bb4ca35f54341be8fc8d3608f71e4d24e # zizmor: ignore[impostor-commit] cargo-llvm-cov (tag-only ref by design)
       - run: cargo llvm-cov --codecov --output-path codecov.json


### PR DESCRIPTION
Route GitHub-hosted CI through the production Azure-backed cache at `https://cache.jdx.dev`, while keeping trusted Namespace jobs on their local shared cache volume.

Fork and otherwise untrusted workflows receive no OIDC permission or secret. They can read the public `jdx/communique` namespace but cannot write to it; trusted release workflows continue using short-lived GitHub OIDC for writes. This also removes the obsolete GitHub Actions cache fallback left behind after the cache-mirror removal.

Validation: `actionlint` (only the existing SC2086 informational finding in `release-plz.yml`) and `git diff --check`.

*AI-assisted — Tool: Codex; model: OpenAI/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cache authentication and remote endpoint; misconfiguration could break cache writes for trusted jobs or widen untrusted job behavior, but read-only fallback is intentional for forks.
> 
> **Overview**
> **CI mbx setup** now treats untrusted/GitHub-hosted jobs as `server` backend (replacing `github`) and points remote cache at **`https://cache.jdx.dev`** instead of `cache.mise.jdx.dev`.
> 
> **OIDC for cache writes** is only configured when `ACTIONS_ID_TOKEN_REQUEST_URL` is present; otherwise the action emits a notice and relies on **public read-only** access to `jdx/communique`. Trusted Namespace workflows still use **`local`** via `ci-impl.yml` unchanged logic (`trusted && 'local' || 'server'`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc02f8e8890888d77b88ee8b4f718dc50c8bb12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated caching to use the shared cache server by default.
  * Trusted workflows continue using local caching where supported.
  * Cache connections now use the unified cache service URL.
  * When GitHub OpenID Connect is unavailable, a notice explains that public read-only cache access is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->