### PR TITLE
fix(docs): show mobile menu in Firefox

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -151,6 +151,11 @@ h3 {
 
 .VPNav {
   border-bottom: 1px solid rgba(185, 103, 255, 0.15) !important;
+}
+
+/* Keep the filter off .VPNav so Firefox does not use it as the containing
+   block for VitePress's fixed mobile navigation screen. */
+.VPNavBar {
   backdrop-filter: blur(16px) saturate(1.2);
 }
 


### PR DESCRIPTION
## Summary

- move the navbar backdrop filter off the `.VPNav` container
- preserve the blur effect without making Firefox treat the fixed mobile menu as a descendant containing block
- keep the mobile nav screen visible while VitePress locks page scrolling

## Verification

- `npm run docs:build`
- opened the built site at a 360×800 viewport and verified the mobile nav fills the viewport below the 64px navbar
- verified `.VPNav` computes to `backdrop-filter: none` while `.VPNavBar` retains `blur(16px) saturate(1.2)`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs theme CSS only; no runtime, auth, or data paths affected.
> 
> **Overview**
> Fixes Firefox hiding VitePress’s fixed mobile navigation by moving **`backdrop-filter`** from **`.VPNav`** to **`.VPNavBar`**.
> 
> The navbar border styling stays on **`.VPNav`**; only the blur/saturation effect moves so Firefox no longer treats the outer nav wrapper as the containing block for the full-screen mobile menu. Visual blur on the bar should be unchanged in other browsers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3645037aabf0e76535acc1c3103bb36a37c529aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile navigation behavior in Firefox by adjusting how the navigation bar’s visual effects are applied.
  - Preserved the navigation bar’s bottom border while preventing layout issues with the fixed mobile navigation screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->