### PR TITLE
docs: complete social and search metadata

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,13 +20,17 @@ function getCommands(cmd: Cmd): string[][] {
 }
 
 const commands = getCommands(spec.cmd);
+const siteUrl = "https://communique.jdx.dev";
+const siteDescription =
+  "Generate polished release notes from git history and pull requests with AI, producing concise changelogs and detailed narratives for GitHub Releases.";
 
 export default defineConfig({
   title: "communiqué",
-  description: "Editorialized release notes powered by AI",
+  description: siteDescription,
   appearance: "force-dark",
   cleanUrls: true,
   lastUpdated: true,
+  sitemap: { hostname: siteUrl },
 
   head: [
     [
@@ -65,31 +69,80 @@ export default defineConfig({
     ["link", { rel: "icon", href: "/favicon.ico", sizes: "48x48" }],
     ["link", { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" }],
     ["link", { rel: "apple-touch-icon", href: "/apple-touch-icon.png" }],
+    ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { name: "theme-color", content: "#b967ff" }],
     [
       "meta",
-      { property: "og:title", content: "communiqué" },
+      {
+        property: "og:title",
+        content: "communiqué — AI-powered release notes",
+      },
     ],
     [
       "meta",
       {
         property: "og:description",
-        content: "Editorialized release notes powered by AI",
+        content: siteDescription,
       },
     ],
     ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:site_name", content: "communiqué" }],
+    ["meta", { property: "og:locale", content: "en_US" }],
     [
       "meta",
       { property: "og:image", content: "https://communique.jdx.dev/og.png" },
     ],
     ["meta", { property: "og:image:width", content: "1200" }],
     ["meta", { property: "og:image:height", content: "630" }],
+    [
+      "meta",
+      {
+        property: "og:image:alt",
+        content: "communiqué — AI-powered release notes",
+      },
+    ],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:site", content: "@jdxcode" }],
     [
       "meta",
       { name: "twitter:image", content: "https://communique.jdx.dev/og.png" },
     ],
+    [
+      "meta",
+      {
+        name: "twitter:image:alt",
+        content: "communiqué — AI-powered release notes",
+      },
+    ],
   ],
+
+  transformHead({ pageData, title, description }) {
+    const url = new URL(
+      pageData.relativePath.replace(/index\.md$/, "").replace(/\.md$/, ""),
+      `${siteUrl}/`,
+    ).toString();
+
+    return [
+      ["link", { rel: "canonical", href: url }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "WebPage",
+          name: title,
+          description,
+          url,
+          isPartOf: { "@type": "WebSite", name: "communiqué", url: siteUrl },
+        }),
+      ],
+    ];
+  },
 
   themeConfig: {
     logo: "/logo.svg",
@@ -125,8 +178,7 @@ export default defineConfig({
     ],
 
     editLink: {
-      pattern:
-        "https://github.com/jdx/communique/edit/main/docs/:path",
+      pattern: "https://github.com/jdx/communique/edit/main/docs/:path",
       text: "Edit this page on GitHub",
     },
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+title: AI-powered release notes from git history
 
 hero:
   name: communiqué

--- a/docs/public/site.webmanifest
+++ b/docs/public/site.webmanifest
@@ -1,0 +1,10 @@
+{
+  "name": "communiqué",
+  "short_name": "communiqué",
+  "icons": [
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" }
+  ],
+  "theme_color": "#b967ff",
+  "background_color": "#0d0221",
+  "display": "standalone"
+}


### PR DESCRIPTION
## Summary

- add per-page canonical, Open Graph, Twitter, and structured data metadata
- publish locale, image alt text, and a web app manifest
- improve homepage title and description signals

## Testing

- npm run docs:build
- verified generated homepage and nested-page metadata

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-site configuration and static metadata only; no runtime product or security-sensitive code paths.
> 
> **Overview**
> **Expands docs site SEO and sharing metadata** by centralizing `siteUrl` and a longer `siteDescription`, wiring a sitemap hostname, and refreshing default Open Graph/Twitter tags (site name, locale, image alt, `@jdxcode`).
> 
> **Adds per-page head output** via `transformHead`: canonical URLs, page-specific `og:url`/titles/descriptions, matching Twitter fields, and JSON-LD `WebPage` structured data tied to the site.
> 
> **Ships a web app manifest** (`site.webmanifest`) linked from the global head, and sets an explicit homepage frontmatter title for stronger title signals on the landing page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035e2b3712f6da97cac53497a9322aed16e2dd2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved page metadata for clearer search engine and social media previews.
  * Added canonical links and structured data to support better page discovery.
  * Added a web app manifest with application branding, colors, icon, and standalone display settings.
  * Updated the home page title to “AI-powered release notes from git history.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->