### PR TITLE
ci(release): publish a signed packslip with each release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -71,6 +71,10 @@ jobs:
     if: ${{ needs.release-plz-release.outputs.tag != '' }}
     permissions:
       contents: write
+      # A called workflow's token can only be narrower than its caller's, so
+      # the packslip's signing and attestation permissions are granted here.
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,3 +160,51 @@ jobs:
           target: ${{ matrix.target }}
           ref: refs/tags/${{ inputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The packslip is this release's signed inventory: every archive's digest,
+  # the executable inside it, the shared objects it needs from the host, and
+  # the workflow identity that signed for all of it. An installer checks a
+  # download against jdx/communique's identity rather than against a key this
+  # project would have to hold. See https://packslip.dev.
+  #
+  # Its own job because the matrix above uploads straight to the release from
+  # seven runners; one document covering the whole release can only be written
+  # once every one of them has landed.
+  packslip:
+    name: Publish the packslip
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download the release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p dist
+          gh release download "$TAG" --repo "$REPO" --dir dist --clobber \
+            --pattern 'communique-*.tar.gz' --pattern 'communique-*.zip'
+          ls -la dist
+      # A consumer that has this file can generate completions, a man page,
+      # and documentation with its own copy of usage, so nothing of
+      # Communiqué's runs on the machine it is installed on.
+      - name: Publish the CLI specification
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          mkdir -p bin
+          tar -xzf dist/communique-x86_64-unknown-linux-gnu.tar.gz -C bin
+          bin/communique usage > communique.usage.kdl
+          gh release upload "$TAG" communique.usage.kdl --repo "$REPO" --clobber
+      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        with:
+          tag: ${{ inputs.tag }}
+          artifacts: dist/communique-*.tar.gz dist/communique-*.zip
+          bin: communique
+          resources: cli-spec/usage=asset:communique.usage.kdl


### PR DESCRIPTION
Part of adopting [packslip](https://packslip.dev) across the jdx.dev CLIs.

Each release now publishes `packslip.sigstore.json` beside the archives — one signed document listing:

- every archive's sha256 and sha512
- the executable inside each one (`communique`, `communique.exe` on Windows)
- the shared objects each build needs from the host, read out of the binaries
- a build-provenance attestation per file, linked by digest
- the source repo, tag, and commit

signed keylessly with this workflow's OIDC identity, so an installer verifies a download against the identity `github.com/jdx/communique` instead of a signing key this project would have to hold and rotate.

`communique usage` is run against the freshly built Linux binary and uploaded as `communique.usage.kdl`, listed as a `cli-spec` resource. A consumer generates completions, a man page, and docs from it with its own copy of usage — nothing of Communiqué's runs on the installing machine.

### Changes

- A new `packslip` job in `release.yml`, needing `upload-assets`. It needs to be its own job: the matrix uploads straight to the release from each runner, so no step there sees the whole release, and one document covering all of it can only be written once every target has landed. It downloads the release's own archives back, generates the CLI spec, and writes the bundle.
- `release-plz.yml` grants `upload-assets` `id-token: write` and `attestations: write`. A called workflow's token can only be equal to or narrower than its caller's, so without this the new job cannot sign or attest.

It runs while the release is still a draft, so the bundle is in place before `publish-release` undrafts it.

### Verification

Ran `communique usage` against the released v1.3.3 linux-gnu binary — exit 0. Rehearsed `packslip create` locally against real release assets of this shape. `zizmor --offline` reports no findings on either changed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline and adds supply-chain signing/attestation, but behavior is additive and scoped to CI release assets rather than application runtime logic.
> 
> **Overview**
> Each release now gets a **keyless signed packslip** (`packslip.sigstore.json`) plus a **`communique.usage.kdl` CLI spec**, so installers can verify downloads against the repo’s GitHub Actions identity instead of a project-held signing key.
> 
> **`release.yml`** adds a **`packslip` job** after the multi-runner **`upload-assets` matrix**: it re-downloads all release archives, runs **`communique usage`** from the Linux GNU tarball and uploads the KDL, then invokes **`jdx/packslip@v0.3.0`** over those archives with the usage file registered as a **`cli-spec/usage`** resource.
> 
> **`release-plz.yml`** extends the **`upload-assets`** reusable-workflow call with **`id-token: write`** and **`attestations: write`**, because the caller’s token permissions cap what the called release workflow can use for signing and attestations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1266e3f3c939841bb04e61257a402dcc75ba92fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a signed inventory covering archives, executables, and the CLI specification.
  - A machine-readable CLI usage specification is generated and published with each release.

- **Security**
  - Release artifacts now receive verifiable signing and provenance attestations, helping users confirm their authenticity and origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->