### PR TITLE
chore(deps): bump mr-boxington to 1.8.1

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -38,6 +38,48 @@ url = "https://github.com/jdx/hk/releases/download/v1.56.1/hk-x86_64-pc-windows-
 url_api = "https://api.github.com/repos/jdx/hk/releases/assets/525632118"
 
 [[tools.mr-boxington]]
+version = "1.8.1"
+backend = "github:jdx/mr-boxington"
+specifiers = ["1.8.1"]
+
+[tools.mr-boxington."platforms.linux-arm64"]
+checksum = "sha256:32ee1fa381884b62cf5f99cd5261ec566403f5a74a7579591af367d2eeb7913c"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207197"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-arm64-musl"]
+checksum = "sha256:520c0d546f345f1f34880af2bcabd6e31106d2c8b58e85cf1993f4472e6ad007"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207199"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.linux-x64"]
+checksum = "sha256:d87968853cc485237e0f739c23e897e3616a569e6a17b27c40e43afec72758a6"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207219"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools.mr-boxington."platforms.linux-x64-musl"]
+checksum = "sha256:dcddf9c35d6c28213d396a9fac9d8987b6741dcf7e003f3dd0396458869b71e2"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207220"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.macos-arm64"]
+checksum = "sha256:541e715487e9348c389011dd2c6fc9640719e3c65ef352dd43abe84a890ba60a"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207201"
+provenance = "github-attestations"
+
+[tools.mr-boxington."platforms.windows-x64"]
+checksum = "sha256:7f8b25823f381da29147cc612fdb858fd3ef21cbcf6927063a5dcd9b1d65011b"
+url = "https://github.com/jdx/mr-boxington/releases/download/v1.8.1/mbx-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/jdx/mr-boxington/releases/assets/545207206"
+provenance = "github-attestations"
+
+[[tools.mr-boxington]]
 version = "1.5.0"
 backend = "github:jdx/mr-boxington"
 specifiers = ["1.5.0"]

--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,7 @@ run = "npm i && exec npm run docs:dev"
 
 # rust is managed by rustup, not mise
 [tools]
-mr-boxington = "1.5.0"
+mr-boxington = "1.8.1"
 usage = "6.6.1"
 hk = "latest"
 pkl = "latest"


### PR DESCRIPTION
## Summary

Bump the pinned `mr-boxington` (the `mbx` Cargo wrapper) from 1.5.0 to 1.8.1, the current release. `mise.lock` updated by `mise use mr-boxington@1.8.1`.

Companion to [jdx/mise#12822](https://github.com/jdx/mise/pull/12822), which did the same bump in the mise repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-tooling version pin only; CI already sets `MBX_DISABLE=1`, so runtime behavior in workflows is unchanged.
> 
> **Overview**
> Pins **mr-boxington** (`mbx`) from **1.5.0** to **1.8.1** in `mise.toml`, matching the current release used as the transparent `cargo` wrapper via `[wrappers.cargo]`.
> 
> `mise.lock` gains a full **1.8.1** platform block (checksums, download URLs, GitHub attestations); the existing **1.5.0** lock entries are left in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045ffa483ceb10b7d66bf6eadf138bc301fff785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `mr-boxington` tool to version 1.8.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->