### PR TITLE
fix(ci): unbreak release-plz PR and packslip upload

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -162,9 +162,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
-      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
-        with:
-          cache: false
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
@@ -172,6 +169,16 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      # mise is set up only after release-plz has run. mise.toml wraps `cargo`
+      # with mbx, and release-plz runs `cargo package` in temporary checkouts
+      # of older commits and of the published crate, each carrying its own
+      # mise.toml. Whenever one of those pins a mr-boxington version that is
+      # not installed on the runner, mise cannot exec mbx and release-plz
+      # fails. release-plz itself only needs rustup's cargo.
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        if: steps.release-plz.outputs.prs_created == 'true'
+        with:
+          cache: false
       - name: Update release PR
         if: steps.release-plz.outputs.prs_created == 'true'
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,10 @@ jobs:
           bin/communique usage > communique.usage.kdl
           gh release upload "$TAG" communique.usage.kdl --repo "$REPO" --clobber
       - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+        # The action uploads with `gh release upload` and no `--repo`, and
+        # this job has no checkout for gh to infer the repository from.
+        env:
+          GH_REPO: ${{ github.repository }}
         with:
           tag: ${{ inputs.tag }}
           artifacts: dist/communique-*.tar.gz dist/communique-*.zip


### PR DESCRIPTION
## Summary

Every `release-plz.yml` run since #304 (2026-09-01) has failed, most recently [run 33959803384](https://github.com/jdx/communique/actions/runs/33959803384). Two independent problems:

### Release-plz PR job

release-plz determines the next version by running `cargo package --list` in temporary checkouts of each commit since the last release, and in the crate downloaded from crates.io. `mise.toml` wraps `cargo` with `mbx`, and mise-action puts that wrapper first on `PATH`. Inside those temp directories mise resolves `mbx` from *that* directory's `mise.toml`. Whenever the pinned mr-boxington version differs from the one installed on the runner, mise cannot exec mbx:

```
error while running `cargo package`: mise ERROR "mbx" couldn't exec process: No such file or directory
```

`MBX_DISABLE=1` cannot help because mbx never runs. This is reproducible locally with mise 2026.9.1 by pinning an uninstalled version. It cannot self-heal: `mise.toml` and `mise.lock` ship inside the crate, so the run on #318 fails on the crates.io 1.3.4 tarball (pins 1.5.0) while the runner has 1.8.1.

Fix: set up mise only after release-plz has run, and only when there is a release PR to update. release-plz itself needs only rustup's cargo. The "Release-plz release" job already works this way.

### Publish the packslip job

The job never checks out the repository, and `jdx/packslip` uploads with `gh release upload` without `--repo`, so `gh` fails with `not a git repository`. That skipped "Publish release" and left v1.3.4 as a draft without its packslip.

Fix: export `GH_REPO` on the packslip step; composite action steps inherit it. (Upstream, packslip should pass `--repo "$GITHUB_REPOSITORY"`.)

## Follow-up

v1.3.4 is still a draft and needs publishing manually:

```
gh release edit v1.3.4 --repo jdx/communique --draft=false
```

## Verification

- `zizmor` passes on both workflows.
- `actionlint` reports only a pre-existing SC2086 info in the "Fix draft release tags" script, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow ordering and environment variables; no application, auth, or release artifact build logic is modified.
> 
> **Overview**
> Fixes two release automation failures that blocked version PRs and draft releases.
> 
> In **release-plz.yml**, **mise** setup now runs **after** `release-plz` and only when a release PR was created. That keeps `cargo package` inside release-plz’s temporary checkouts on plain rustup **cargo** instead of a mise **mbx** wrapper that can fail when historical `mise.toml` pins an uninstalled mr-boxington version.
> 
> In **release.yml**, the **packslip** step sets **`GH_REPO`** so **`gh release upload`** inside the action knows the repository in a job that never checks out the repo (the action omits `--repo`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8859aa91bef169d7bb40081656be1ec7756fe87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated release pull request creation by running the release process before optional environment setup.
  * Reduced unnecessary setup when no release pull request is created.
  * Improved automated release uploads by ensuring artifacts are associated with the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->