### PR TITLE
v1.3.5: Release automation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped the default model from `claude-opus-4-7` to `claude-opus-4-8`.
 
+## [1.3.5](https://github.com/jdx/communique/releases/tag/v1.3.5) - 2026-09-05
+
+## Fixed
+
+- *(ci)* Unbroke release-plz version PRs and packslip uploads by reordering mise setup and setting `GH_REPO` ([#319](https://github.com/jdx/communique/pull/319))
+
+### Other
+
+- *(deps)* Bumped `mr-boxington` to 1.8.1 ([#318](https://github.com/jdx/communique/pull/318))
+
 ## [1.3.4](https://github.com/jdx/communique/releases/tag/v1.3.4) - 2026-09-01
 
 ## Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "clx",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"

--- a/communique.usage.kdl
+++ b/communique.usage.kdl
@@ -2,7 +2,7 @@
 min_usage_version "4.0"
 name communique
 bin communique
-version "1.3.4"
+version "1.3.5"
 about "Editorialized release notes powered by AI"
 usage "Usage: communique [OPTIONS] <COMMAND>"
 unknown_flags error

--- a/docs/cli/commands.json
+++ b/docs/cli/commands.json
@@ -456,7 +456,7 @@
     "sources": {},
     "files": []
   },
-  "version": "1.3.4",
+  "version": "1.3.5",
   "usage": "Usage: communique [OPTIONS] <COMMAND>",
   "complete": {},
   "about": "Editorialized release notes powered by AI",

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 
 **Usage:** `communique [FLAGS] <SUBCOMMAND>`
 
-**Version:** 1.3.4
+**Version:** 1.3.5
 
 - **Usage:** `communique [FLAGS] <SUBCOMMAND>`
 


### PR DESCRIPTION
A tiny maintenance release with no user-facing changes. It repairs the broken release automation (release-plz version PRs and packslip uploads had been failing) and bumps internal tooling.

## Fixed

- Unbroke the release pipeline: mise is now set up only after release-plz runs (and only when there's a release PR to update), so `cargo package` no longer fails when a historical `mise.toml` pins an uninstalled `mr-boxington` version. The packslip upload step now exports `GH_REPO` so `gh release upload` works in the job that doesn't check out the repo. ([#319](https://github.com/jdx/communique/pull/319)) (@jdx)

_Otherwise internal only: bumped the `mr-boxington` (`mbx`) cargo-wrapper pin to 1.8.1 ([#318](https://github.com/jdx/communique/pull/318))._

## 💚 Sponsor communique

communique is built and maintained by [@jdx](https://github.com/jdx), an open source developer at [**entire.io**](https://entire.io/), the title sponsor of his open source work.

If communique drafts your release notes or changelogs, please consider becoming an [individual or company sponsor](https://jdx.dev/sponsors.html). Your support funds ongoing development and helps keep communique fast, free, and independent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/doc metadata only; no runtime or CI workflow changes in this diff.
> 
> **Overview**
> **Release cut for v1.3.5** — no application logic in this diff; it publishes the maintenance release and keeps version metadata aligned.
> 
> **`CHANGELOG.md`** adds the **1.3.5** section (2026-09-05) documenting CI fixes for release-plz version PRs and packslip uploads ([#319]) and the **`mr-boxington` 1.8.1** tooling bump ([#318]). The **`[Unreleased]`** section still lists the pending default model change to **`claude-opus-4-8`**.
> 
> **Version strings** move **1.3.4 → 1.3.5** in **`Cargo.toml`**, **`Cargo.lock`**, generated **`communique.usage.kdl`**, and CLI docs (**`docs/cli/commands.json`**, **`docs/cli/index.md`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f0ab6d5c8eb0b8a6ce4afab23ae5d825c3b27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->