### PR TITLE
chore(release): v1.4.0: Claude Fable 5.1 by default, reviewable drafts, and native shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,31 @@ _Otherwise a maintenance release: CI hardening, `mbx`/`mr-boxington` tooling upd
 
 - *(generate)* Support `communique generate HEAD --changelog` as an intentional `[Unreleased]` target — replaces the existing `## [Unreleased]` section in place instead of inserting a literal `## [HEAD]` entry, with prompt/title labels switched to "unreleased" wording and an early guard rejecting `HEAD --github-release`. ([#121](https://github.com/jdx/communique/pull/121)) (@ThomasK33)
 
+## [1.4.0](https://github.com/jdx/communique/compare/v1.3.5...v1.4.0) - 2026-09-11
+
+### Added
+
+- add reviewable drafts and scoped release notes ([#335](https://github.com/jdx/communique/pull/335))
+- use Claude Fable 5.1 by default ([#332](https://github.com/jdx/communique/pull/332))
+- *(cli)* publish native completions in packslip ([#325](https://github.com/jdx/communique/pull/325))
+
+### Fixed
+
+- keep release notes concise and avoid copying reference boilerplate ([#334](https://github.com/jdx/communique/pull/334))
+- preserve Anthropic thinking blocks in tool loops ([#333](https://github.com/jdx/communique/pull/333))
+
+### Other
+
+- *(deps)* update dependency usage to v6.8.0 ([#329](https://github.com/jdx/communique/pull/329))
+- write PR titles and descriptions for release notes ([#331](https://github.com/jdx/communique/pull/331))
+- *(deps)* update zizmorcore/zizmor-action action to v0.6.3 ([#328](https://github.com/jdx/communique/pull/328))
+- *(deps)* update actions/deploy-pages action to v5 ([#330](https://github.com/jdx/communique/pull/330))
+- *(deps)* lock file maintenance ([#327](https://github.com/jdx/communique/pull/327))
+- *(deps)* bump mr-boxington to 1.8.3 ([#326](https://github.com/jdx/communique/pull/326))
+- *(ci)* bump packslip to v1.1.1 ([#324](https://github.com/jdx/communique/pull/324))
+- *(release)* bump packslip action to v1.0.0 ([#323](https://github.com/jdx/communique/pull/323))
+- enforce conventional commits
+
 ## [1.3.3](https://github.com/jdx/communique/compare/v1.3.2...v1.3.3) - 2026-08-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "communique"
-version = "1.3.5"
+version = "1.4.0"
 dependencies = [
  "clx",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communique"
-version = "1.3.5"
+version = "1.4.0"
 edition = "2024"
 resolver = "3"
 description = "Editorialized release notes powered by AI"


### PR DESCRIPTION
Communique now generates with `claude-fable-5-1` by default, can save a draft you review and edit before publishing without another model call, supports package-scoped notes for monorepos, and ships native shell completions.

## Added

- **Review-before-publish drafts.** `communique generate --draft release.json` saves the title, body, changelog, and coverage review as editable JSON; `communique publish release.json` pushes the edited content to the GitHub Release without invoking the model again. Publishing verifies the remote tag still points at the commit recorded at generation time and stops if the tag moved. `--review-report` writes a Markdown coverage report marking each scoped commit as included, omitted, or uncertain, and `--migration-guide` writes an upgrade guide (or states that no migration is needed). ([#335](https://github.com/jdx/communique/pull/335)) (@jdx)
  ```sh
  communique generate v2.0.0 --draft release.json --review-report review.md --migration-guide upgrade.md
  # Edit release_title and release_body in release.json.
  communique publish release.json --dry-run
  communique publish release.json
  ```
- **Package-scoped releases and baseline filters.** `--package`, repeatable `--path`, and `--changelog-path` generate notes and changelogs for one part of a monorepo, with defaults configurable under `[packages.<name>]` in `communique.toml`. `--tag-pattern 'cli/v*'` and `--channel stable|all` control which reachable tags are considered as the previous release; an explicit previous ref still wins. The selected range is printed before generation. ([#335](https://github.com/jdx/communique/pull/335)) (@jdx)
- **Label-based editorial rules.** A `[rules]` table with `include_labels`, `exclude_labels`, and `[rules.categories]` label-to-category mappings controls which PRs appear and where. Include labels override exclusions and the default internal-change filter. Requires `GITHUB_TOKEN`; inaccessible PRs fail generation rather than silently ignoring the rules. ([#335](https://github.com/jdx/communique/pull/335)) (@jdx)
- **`--preserve-sections`** updates only the `<!-- communique:start -->` / `<!-- communique:end -->` block of an existing GitHub Release (with `--github-release` or `--draft`), keeping the existing title and any hand-written text around it. If no markers exist, a managed section is appended. ([#335](https://github.com/jdx/communique/pull/335)) (@jdx)
- **`communique completion <shell>`** emits native completion scripts for Bash, Zsh, Fish, and PowerShell. The scripts are also published as signed Packslip release assets alongside the usage spec, so installers can register completions without a separate `usage` binary. ([#325](https://github.com/jdx/communique/pull/325)) (@jdx)

## Changed

- The built-in default model is now `claude-fable-5-1` (previously `claude-opus-4-8`) when neither `--model` nor `[defaults].model` is set. The `communique init` template and docs reflect the new default. ([#332](https://github.com/jdx/communique/pull/332)) (@jdx)
- Default generation guidance now produces shorter, less repetitive notes: it leads with concrete changes, groups related PRs by user outcome, avoids "small release" openers and internal maintenance inventories, and treats existing releases as style reference only—ignoring workflow-appended footers such as sponsor blurbs unless project instructions request them. Maintenance-only releases get a one-sentence body plus compare link. ([#334](https://github.com/jdx/communique/pull/334)) (@jdx)

## Fixed

- Anthropic tool-use loops no longer break when the API returns signed `thinking` blocks (or other unrecognized block types). Assistant content is now stored and echoed verbatim in the conversation history, which the Anthropic API requires for thinking-enabled models like Fable 5.1. ([#333](https://github.com/jdx/communique/pull/333)) (@jdx)

**Full Changelog**: `v1.3.5...v1.4.0`