### PR TITLE
chore(release): bump packslip action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           tar -xzf dist/communique-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/communique usage > communique.usage.kdl
           gh release upload "$TAG" communique.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
+      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
         # The action uploads with `gh release upload` and no `--repo`, and
         # this job has no checkout for gh to infer the repository from.
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           tar -xzf dist/communique-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/communique usage > communique.usage.kdl
           gh release upload "$TAG" communique.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@433c0c0f033e64c22f12433471768c255ef2bd93 # v0.3.0
+      - uses: jdx/packslip@0121abf6972fe6ca13633233402439a715f4cc0e # v1.0.0
         # The action uploads with `gh release upload` and no `--repo`, and
         # this job has no checkout for gh to infer the repository from.
         env:


### PR DESCRIPTION
## Summary
- Bumps the pinned `jdx/packslip` action from v0.3.0 to v1.0.0.
- v1.0.0 declares the manifest format stable, fixes the `packslip.dev/releases/v1` predicate URL that previously 404d, and requires every artifact to declare a format (already satisfied here — every artifact is an archive, which infers its format from the file name).

## Test plan
- [ ] Next tagged release runs the packslip step successfully and uploads `packslip.sigstore.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin in the release workflow; no application or runtime code changes.
> 
> **Overview**
> Updates the **Publish the packslip** release job to use **`jdx/packslip@v1.0.1`** (pinned commit) instead of **v0.3.0**. Inputs (`tag`, `artifacts`, `bin`, `resources`, `GH_REPO`) are unchanged.
> 
> This picks up packslip’s stable manifest format, the fixed `packslip.dev/releases/v1` predicate URL, and stricter artifact format handling on the next tagged release (including uploading `packslip.sigstore.json` per the test plan).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 232c58513dca385f6578591ba8c088a78599b710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

*AI-assisted — Tool: Claude Code; model: anthropic/claude-sonnet-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to use a newer version of its release metadata action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->