### PR TITLE
chore(ci): bump packslip to v1.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           tar -xzf dist/communique-x86_64-unknown-linux-gnu.tar.gz -C bin
           bin/communique usage > communique.usage.kdl
           gh release upload "$TAG" communique.usage.kdl --repo "$REPO" --clobber
-      - uses: jdx/packslip@a6eddff2d884891faa2efbec374b48e7053df2c4 # v1.0.1
+      - uses: jdx/packslip@a0d434ad57571c62dbd0ab5095b4eff607a71fd3 # v1.1.1
         # The action uploads with `gh release upload` and no `--repo`, and
         # this job has no checkout for gh to infer the repository from.
         env:


### PR DESCRIPTION
Update the release workflow to use packslip v1.1.1 at its immutable commit SHA. This release pins the nested provenance action, so repositories enforcing full-length action SHAs can load the composite action.

Validation: `git diff --check`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in CI with no application or release-artifact logic changes.
> 
> **Overview**
> Updates the **Publish the packslip** job in `.github/workflows/release.yml` to use **`jdx/packslip@v1.1.1`** (commit `a0d434ad…`) instead of **v1.0.1**. Release behavior is unchanged: same artifacts, `communique` binary, and `communique.usage.kdl` resource mapping.
> 
> The bump is mainly for **supply-chain pinning**—v1.1.1 fixes nested action references so workflows that require full commit SHAs can load the composite action without resolution failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52fa5315db6ffe868a2ad1802f5a6eb216ac42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process tooling to a newer pinned version.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->