### PR TITLE
feat: use Claude Fable 5.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Avoid marketing language.
 """
 
 [defaults]
-model = "claude-opus-4-8"
+model = "claude-fable-5-1"
 repo = "owner/repo"
 max_tokens = 16384
 ```
@@ -199,7 +199,7 @@ examples and release PR workflows.
 
 ```sh
 communique generate v1.2.0 --repo owner/repo
-communique generate v1.2.0 --model claude-opus-4-8
+communique generate v1.2.0 --model claude-fable-5-1
 communique generate v1.2.0 --provider openai --base-url https://api.example.com/v1
 communique generate v1.2.0 --quiet
 communique generate v1.2.0 --verbose

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -36,14 +36,14 @@ Default parameters for generation. All values can be overridden via CLI flags.
 
 ```toml
 [defaults]
-model = "claude-opus-4-8"
+model = "claude-fable-5-1"
 max_tokens = 16384
 repo = "owner/repo"
 ```
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `model` | Model identifier | `claude-opus-4-8` |
+| `model` | Model identifier | `claude-fable-5-1` |
 | `max_tokens` | Maximum tokens permitted per model response (billing is based on actual usage) | `16384` |
 | `repo` | GitHub repo in `owner/repo` format | Auto-detected from git remote |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ const TEMPLATE: &str = r#"# Extra instructions appended to the system prompt.
 #context = ""
 
 [defaults]
-#model = "claude-opus-4-8"
+#model = "claude-fable-5-1"
 #max_tokens = 16384
 #repo = "owner/repo"
 #provider = "anthropic"

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -63,6 +63,13 @@ fn validate_generate_options(opts: &GenerateOptions) -> miette::Result<()> {
     Ok(())
 }
 
+fn resolve_model(opts: &GenerateOptions, defaults: &Defaults) -> String {
+    opts.model
+        .clone()
+        .or(defaults.model.clone())
+        .unwrap_or_else(|| "claude-fable-5-1".into())
+}
+
 fn release_title_description<'a>(title: &'a str, label: &str) -> Option<&'a str> {
     let rest = title.strip_prefix(label)?;
     if rest.chars().next().is_some_and(char::is_alphanumeric) {
@@ -180,11 +187,7 @@ async fn gather_context(opts: &GenerateOptions, job: &Arc<ProgressJob>) -> miett
     .unwrap_or_default();
     let defaults = config.defaults.unwrap_or_default();
 
-    let model = opts
-        .model
-        .clone()
-        .or(defaults.model.clone())
-        .unwrap_or_else(|| "claude-opus-4-8".into());
+    let model = resolve_model(opts, &defaults);
     let max_tokens = opts
         .max_tokens
         .or(defaults.max_tokens)
@@ -469,6 +472,20 @@ mod tests {
         };
 
         validate_generate_options(&opts).unwrap();
+    }
+
+    #[test]
+    fn test_resolve_model_precedence_and_default() {
+        let mut opts = test_opts("v1.0.0");
+        let mut defaults = Defaults::default();
+
+        assert_eq!(resolve_model(&opts, &defaults), "claude-fable-5-1");
+
+        defaults.model = Some("config-model".into());
+        assert_eq!(resolve_model(&opts, &defaults), "config-model");
+
+        opts.model = Some("cli-model".into());
+        assert_eq!(resolve_model(&opts, &defaults), "cli-model");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Communique now uses `claude-fable-5-1` when neither `--model` nor `[defaults].model` selects a model. This moves release-note generation to the newest Fable model while preserving both existing override mechanisms.

The generated configuration template, README examples, and configuration reference now show the same default. A regression test covers the CLI override, repository configuration, and built-in fallback precedence.

Validation:
- `mise run lint`
- `mise exec -- cargo test` (189 tests passed before the focused regression test was added)
- `mise exec -- cargo test test_resolve_model_precedence_and_default`

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and documentation default only; explicit `--model` and `communique.toml` overrides are unchanged, with no auth or data-path changes.
> 
> **Overview**
> **Default LLM for release-note generation** is now `claude-fable-5-1` instead of `claude-opus-4-8` when neither `--model` nor `[defaults].model` in `communique.toml` is set. CLI and config overrides behave the same as before.
> 
> Model selection is centralized in a new **`resolve_model`** helper in `generate.rs`, and a unit test locks in precedence: CLI flag, then config default, then the built-in fallback. The **`communique init` template**, **README** examples, and **configuration guide** all document the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cc8bedb59df36cee044812169c3d5a4ece55fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default model to `claude-fable-5-1` when no model is specified.

- **Documentation**
  - Updated configuration examples and CLI usage guidance to reference `claude-fable-5-1`.
  - Clarified the documented default model value.

- **Bug Fixes**
  - Preserved model selection precedence so an explicitly provided CLI model continues to override the configured default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->