### PR TITLE
fix: preserve Anthropic thinking blocks in tool loops

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -17,38 +17,12 @@ pub struct AnthropicProvider {
     base_url: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct Message {
-    role: String,
-    content: Vec<ContentBlock>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
-enum ContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: Value,
-    },
-    #[serde(rename = "tool_result")]
-    ToolResult {
-        tool_use_id: String,
-        content: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        is_error: Option<bool>,
-    },
-}
-
 #[derive(Debug, Serialize)]
 struct MessagesRequest {
     model: String,
     max_tokens: u32,
     system: String,
-    messages: Vec<Message>,
+    messages: Vec<Value>,
     tools: Vec<ToolDef>,
 }
 
@@ -61,9 +35,24 @@ struct ToolDef {
 
 #[derive(Debug, Deserialize)]
 struct MessagesResponse {
-    content: Vec<ContentBlock>,
+    content: Vec<Value>,
     stop_reason: Option<String>,
     usage: ApiUsage,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum ExtractedContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    #[serde(other)]
+    Other,
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,12 +116,6 @@ impl LlmClient for AnthropicProvider {
         tools: &'a [ToolDefinition],
     ) -> Pin<Box<dyn Future<Output = Result<TurnResponse>> + Send + 'a>> {
         Box::pin(async move {
-            let messages: Vec<Message> = conversation
-                .messages
-                .iter()
-                .map(|v| serde_json::from_value(v.clone()).expect("invalid conversation message"))
-                .collect();
-
             let tool_defs: Vec<ToolDef> = tools
                 .iter()
                 .map(|t| ToolDef {
@@ -146,7 +129,7 @@ impl LlmClient for AnthropicProvider {
                 model: self.model.clone(),
                 max_tokens: self.max_tokens,
                 system: system.into(),
-                messages,
+                messages: conversation.messages.clone(),
                 tools: tool_defs,
             };
 
@@ -168,33 +151,25 @@ impl LlmClient for AnthropicProvider {
 
             let response: MessagesResponse = resp.json().await?;
 
-            // Append assistant message to conversation
-            let assistant_content: Vec<Value> = response
-                .content
-                .iter()
-                .map(|b| serde_json::to_value(b).unwrap())
-                .collect();
-            conversation.messages.push(json!({
-                "role": "assistant",
-                "content": assistant_content,
-            }));
-
             // Extract text and tool calls
             let mut text_parts = Vec::new();
             let mut tool_calls = Vec::new();
             for block in &response.content {
-                match block {
-                    ContentBlock::Text { text } => text_parts.push(text.as_str()),
-                    ContentBlock::ToolUse { id, name, input } => {
-                        tool_calls.push(ToolCall {
-                            id: id.clone(),
-                            name: name.clone(),
-                            input: input.clone(),
-                        });
+                match serde_json::from_value(block.clone())? {
+                    ExtractedContentBlock::Text { text } => text_parts.push(text),
+                    ExtractedContentBlock::ToolUse { id, name, input } => {
+                        tool_calls.push(ToolCall { id, name, input });
                     }
-                    _ => {}
+                    ExtractedContentBlock::Other => {}
                 }
             }
+
+            // Preserve every assistant content block so Anthropic can verify
+            // signed thinking blocks on the next turn in a tool-use loop.
+            conversation.messages.push(json!({
+                "role": "assistant",
+                "content": response.content,
+            }));
 
             let text = if text_parts.is_empty() {
                 None
@@ -310,6 +285,7 @@ mod tests {
             .respond_with(
                 wiremock::ResponseTemplate::new(200).set_body_json(json!({
                     "content": [
+                        {"type": "thinking", "thinking": "", "signature": "signed-thinking"},
                         {"type": "text", "text": "Let me read that."},
                         {"type": "tool_use", "id": "tc_1", "name": "read_file", "input": {"path": "README.md"}}
                     ],
@@ -327,6 +303,28 @@ mod tests {
         assert_eq!(resp.tool_calls.len(), 1);
         assert_eq!(resp.tool_calls[0].name, "read_file");
         assert_eq!(resp.tool_calls[0].input["path"], "README.md");
+        assert_eq!(conv.messages[1]["content"][0]["type"], "thinking");
+        assert_eq!(
+            conv.messages[1]["content"][0]["signature"],
+            "signed-thinking"
+        );
+
+        provider.append_tool_results(
+            &mut conv,
+            &[ToolResult {
+                tool_call_id: "tc_1".into(),
+                content: "contents".into(),
+                is_error: false,
+            }],
+        );
+        provider.send_turn("system", &mut conv, &[]).await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        let second_request: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(
+            second_request["messages"][1]["content"][0],
+            json!({"type": "thinking", "thinking": "", "signature": "signed-thinking"})
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- preserve every Anthropic assistant content block verbatim in conversation history
- continue extracting text and tool calls while allowing signed thinking blocks and future block types
- verify a signed thinking block is included unchanged in the next tool-loop request

## Validation
- `mise run lint`
- `mise exec -- cargo test` (190 tests)

Fixes the issue identified in #332.

*AI-assisted — Tool: Codex; model: openai/GPT-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all Anthropic assistant message content is serialized in multi-turn tool flows; incorrect handling could break API validation or drop tool/text parsing, but scope is limited to the Anthropic provider with new regression tests.
> 
> **Overview**
> Fixes Anthropic **tool-use loops** breaking when the API returns **signed `thinking` blocks** (and other block types) by no longer round-tripping assistant content through a narrow typed schema.
> 
> **`AnthropicProvider`** now sends `conversation.messages` as raw JSON and appends the API’s `response.content` **verbatim** to history, while still parsing only `text` and `tool_use` blocks into `TurnResponse` via a new `ExtractedContentBlock` enum with **`serde(other)`** for unknown types.
> 
> Tests assert a thinking block with signature is stored and echoed unchanged on the **second** messages request after tool results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923056b5bed4114e26ac4ebaef5201bebbd3b6c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->